### PR TITLE
Make Jarvis inform the users in Github a PR was merged successfully

### DIFF
--- a/lib/lita-jls/util.rb
+++ b/lib/lita-jls/util.rb
@@ -240,6 +240,14 @@ module LitaJLS
       raise e.class, "Failed adding label '#{labels}' to issue #{issue} on #{project}: #{e}"
     end # def github_issue_label
 
+    def github_issue_comment(project, issue, comment)
+      logger.debug('Adding a comment to an given issue', :project => project, :issue => issue, :comment => comment)
+      github_client.add_comment(project, issue, comment) unless comment.empty?
+    rescue => e
+      raise e.class, "Failed adding a comment #{comment} to issue #{issue} on #{project}: #{e}"
+
+    end # def github_issue_comment
+
     def git(gitdir, *args)
       Dir.chdir(gitdir) do
         system!("git", *args)

--- a/lib/lita/handlers/jls.rb
+++ b/lib/lita/handlers/jls.rb
@@ -166,6 +166,7 @@ module Lita
           labels = branches.reject { |b| b == "master" }
           github_issue_label("#{user}/#{project}", pr.to_i, labels)
         end
+        github_issue_comment("#{user}/#{project}", pr.to_i, "Merged sucessfully into #{branchspec}!")
       rescue => e
         msg.reply("(stare) Error: #{e.inspect}")
         raise


### PR DESCRIPTION
As we're not using the green button of Github, a first look at our PR just seem closed. This here adds a  message to the Issue to the user knows his PR was merged and it's happy.
