### PR TITLE
Fix/follow redirect for patch

### DIFF
--- a/lib/lita-jls/util.rb
+++ b/lib/lita-jls/util.rb
@@ -40,19 +40,6 @@ module LitaJLS
       true
     end # cla?
 
-    def logstash_team?(user)
-      ["electrical",
-       "jordansissel",
-       "ph",
-       "colinsurprenant",
-       "jsvd",
-       "untergeek",
-       "talevy",
-       "kurtado",
-       "suyograo",
-       "purbon"].include?(user.downcase)
-    end
-
     # Clone a git url into a local path.
     #
     # This caches a remote git repo and performs a clone against that in

--- a/lib/lita/handlers/jls.rb
+++ b/lib/lita/handlers/jls.rb
@@ -186,7 +186,7 @@ module Lita
                          source_github_pr[:body] + "\nMoved from #{source_url}")
       end
 
-      @private
+      private
       # downloads the patch file in mail format and saves it to a file
       def download_patch(pr_url, pr_num)
         http = Faraday.new("https://github.com")
@@ -208,7 +208,6 @@ module Lita
         return patch_file
       end
 
-      @private
       def parse_github_url(url)
         github_parser = LitaJLS::GithubUrlParser.parse(url, :link => :repository)
         github_parser.validate!

--- a/lita-jls.gemspec
+++ b/lita-jls.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-jls"
-  spec.version       = "0.0.10"
+  spec.version       = "0.0.11"
   spec.authors       = ["Jordan Sissel"]
   spec.email         = ["jls@semicomplete.com"]
   spec.description   = %q{Some stuff for the lita.io bot}

--- a/lita-jls.gemspec
+++ b/lita-jls.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "lita", ">= 3.3"
   spec.add_runtime_dependency "cabin", ">= 0"
   spec.add_runtime_dependency "faraday", ">= 0"
+  spec.add_runtime_dependency "faraday_middleware"
 
   # For access to Github's api
   spec.add_runtime_dependency "octokit", ">= 0"


### PR DESCRIPTION
This week github changed their url for downloading patch files, their api still return the old url in the json document. Jarvis wasn't following the redirect of those calls.