### PR TITLE
Initial work on the rewrite of Jarvis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# lita-jarvis
+
+TODO: Add a description of the plugin.
+
+## Installation
+
+Add lita-jarvis to your Lita instance's Gemfile:
+
+``` ruby
+gem "lita-jarvis"
+```
+
+## Configuration
+
+TODO: Describe any configuration attributes the plugin exposes.
+
+## Usage
+
+TODO: Describe the plugin's features and how to use them.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/lib/jarvis/clamp_delegate.rb
+++ b/lib/jarvis/clamp_delegate.rb
@@ -1,0 +1,52 @@
+require "clamp"
+require "shellwords"
+
+module Jarvis module ClampDelegate
+  # Delegate a Lita route to a Clamp::Command class.
+  #
+  # This method will return a Proc that is intended for use as a Lita route callback
+  # 
+  # For example:
+  #
+  #     route(/^foo/, :command => true, &Jarvis::ClampDelegate.delegate(Foo)
+  #
+  # The 'foo' command, when invoked via the Lita bot, will pass the whole
+  # message body into the Foo clamp command as if it were run via the command
+  # line.
+  def self.delegate(command_class)
+    if !command_class.ancestors.include?(Clamp::Command)
+      raise ArgumentError, "Cannot delegate to `#{command_class}` because it is not a subclass of Clamp::Command"
+    end
+    callback(command_class)
+  end
+
+  private
+  def self.callback(command_class)
+    lambda do |request|
+      name, *args = Shellwords.shellsplit(request.message.body)
+      cmd = command_class.new(name)
+
+      inject_methods(cmd, request)
+
+      begin
+        cmd.run(args)
+      rescue ::Clamp::UsageError => e
+        cmd.puts(["Error: #{e}", cmd.help].join("\n"))
+      rescue ::Clamp::HelpWanted => e
+        cmd.puts(cmd.help)
+      end
+      nil
+    end
+  end
+
+  def self.inject_methods(obj, request)
+    # Override `puts` and `p` calls from within `obj` to cause them to reply
+    # instead of printing to stdout.
+    obj.define_singleton_method(:puts) do |message|
+      request.reply(message)
+    end
+    obj.define_singleton_method(:p) do |message|
+      request.reply(message.inspect)
+    end
+  end
+end end

--- a/lib/jarvis/commands/bounce.rb
+++ b/lib/jarvis/commands/bounce.rb
@@ -1,0 +1,8 @@
+require "clamp"
+
+module Jarvis module Command class Bounce < Clamp::Command
+  def execute
+    puts "Bouncing..."
+    exec($0)
+  end
+end end end

--- a/lib/jarvis/commands/merge.rb
+++ b/lib/jarvis/commands/merge.rb
@@ -1,0 +1,15 @@
+require "clamp"
+
+module Jarvis module Command class Merge < Clamp::Command
+
+  banner "Merge a pull request into one or more branches."
+
+  parameter "URL", "The URL to merge"
+  parameter "BRANCHES ...", "The branches to merge"
+
+  def execute
+    puts "Merging: #{url} into #{branches_list}"
+  rescue => e
+    puts "An error occurred: #{e.class} - #{e}\n" + e.backtrace.join("\n")
+  end
+end end end

--- a/lib/jarvis/error.rb
+++ b/lib/jarvis/error.rb
@@ -1,0 +1,2 @@
+module Jarvis class Error < StandardError 
+end end

--- a/lib/jarvis/mixins/fancy_route.rb
+++ b/lib/jarvis/mixins/fancy_route.rb
@@ -17,7 +17,7 @@ module Jarvis module Mixins module FancyRoute
     pattern = Regexp.new("^#{Regexp.escape(pattern)}(\\s|$)") if pattern.is_a?(String)
 
     # Default to the NORMAL workpool
-    pool = options.fetch(:pool, WorkPool::NORMAL)
+    pool = options.fetch(:pool, ::Jarvis::WorkPool::NORMAL)
 
     # Invoke the normal Lita route method to setup our new fancy route. :)
     route(pattern, options, &pool_delegate(pool, &handler))

--- a/lib/jarvis/mixins/fancy_route.rb
+++ b/lib/jarvis/mixins/fancy_route.rb
@@ -1,0 +1,49 @@
+require "clamp"
+require "jarvis/workpool"
+require "jarvis/clamp_delegate"
+require_relative "./pool_delegate"
+
+module Jarvis module Mixins module FancyRoute
+  include ::Jarvis::Mixins::PoolDelegate
+
+  def fancy_route(pattern, handler=nil, options={}, &block)
+    if handler.ancestors.include?(Clamp::Command)
+      options[:help] = { pattern => handler.description || "#{pattern} #{handler.derived_usage_description}" }
+    end
+
+    handler = fancy_handler(handler, &block)
+
+    # Turn a string "foo" into a regexp /^foo(\s|$)/
+    pattern = Regexp.new("^#{Regexp.escape(pattern)}(\\s|$)") if pattern.is_a?(String)
+
+    # Default to the NORMAL workpool
+    pool = options.fetch(:pool, WorkPool::NORMAL)
+
+    # Invoke the normal Lita route method to setup our new fancy route. :)
+    route(pattern, options, &pool_delegate(pool, &handler))
+  end
+
+  def fancy_handler(handler, &block)
+    if handler.nil?
+      raise "Nothing to route to - no block or handler given for #{regexp} route." if block.nil?
+
+      # Use the block as the handler instead.
+      handler = block
+    end
+
+    case handler
+    when Proc
+      # nothing needed to be done
+    when Symbol
+      # nothing needed to be done
+    when Class
+      if handler.ancestors.include?(::Clamp::Command)
+        handler = ::Jarvis::ClampDelegate.delegate(handler)
+      end
+    else
+      raise "Unsupported handler type #{handler.class} (#{handler.inspect})"
+    end
+
+    handler
+  end
+end end end

--- a/lib/jarvis/mixins/pool_delegate.rb
+++ b/lib/jarvis/mixins/pool_delegate.rb
@@ -7,7 +7,7 @@ module Jarvis module Mixins module PoolDelegate
   end
 
   def pool_execute(pool_name, callback_proc, request)
-    pool = WorkPool.fetch(pool_name)
+    pool = ::Jarvis::WorkPool.fetch(pool_name)
     pool.post do
       # TODO(sissel): Track active commands so that debugging/inspection of
       #   active tasks can occur.

--- a/lib/jarvis/mixins/pool_delegate.rb
+++ b/lib/jarvis/mixins/pool_delegate.rb
@@ -1,0 +1,27 @@
+require "jarvis/workpool"
+
+module Jarvis module Mixins module PoolDelegate
+  def pool_delegate(pool_name, &callback)
+    lambda do |request|
+      begin
+        pool = WorkPool.fetch(pool_name)
+        pool.post do
+          # TODO(sissel): Note what command is being executed and at what time.
+          # TODO(sissel): Redirect $stdout and $stderr
+          begin
+            callback.call(request)
+          rescue => e
+            # TODO(sissel): Mark this job as failed
+            request.reply(t("unhandled exception", :exception => e))
+            request.reply(e.backtrace.join("\n"))
+          end
+          # TODO(sissel): Mark this job as complete.
+        end
+      rescue Concurrent::RejectedExecutionError => e
+        request.reply(t("rejected execution", :pool => pool_name))
+      rescue => e
+        request.reply(t("unhandled exception", :exception => e))
+      end
+    end
+  end
+end end end

--- a/lib/jarvis/workpool.rb
+++ b/lib/jarvis/workpool.rb
@@ -1,0 +1,52 @@
+require "concurrent"
+
+class WorkPool
+  ADMINISTRATIVE = :ADMINISTRATIVE
+  NORMAL = :NORMAL
+
+  class InvalidWorkPoolName < StandardError; end
+
+  class << self
+    def setup_singleton
+      @singleton = self.new
+      nil
+    end
+
+    def fetch(name)
+      @singleton.fetch(name)
+    end
+
+    def post(name, &block)
+      fetch(name).post(&block)
+    end
+  end
+
+  def initialize
+    # TODO(sissel): Move this to a module.
+    @pools = {
+      ADMINISTRATIVE => Concurrent::ThreadPoolExecutor.new(
+        max_threads: 1,
+        max_queue: 1,
+        fallback_policy: :abort
+      ),
+      NORMAL => Concurrent::ThreadPoolExecutor.new(
+        max_threads: 5,
+        max_queue: 1,
+        fallback_policy: :abort
+      )
+    }
+
+    @pools.freeze
+  end
+
+  # Get a pool by name.
+  def fetch(name)
+    @pools.fetch(name)
+  rescue KeyError
+    raise InvalidWorkPoolName, "No such work pool `#{name.inspect}`"
+  end
+
+  def post(name, &block)
+    fetch(name).post(&block)
+  end
+end

--- a/lib/jarvis/workpool.rb
+++ b/lib/jarvis/workpool.rb
@@ -1,10 +1,11 @@
 require "concurrent"
+require "jarvis/error"
 
-class WorkPool
+module Jarvis class WorkPool
   ADMINISTRATIVE = :ADMINISTRATIVE
   NORMAL = :NORMAL
 
-  class InvalidWorkPoolName < StandardError; end
+  class InvalidWorkPoolName < Jarvis::Error; end
 
   class << self
     def setup_singleton
@@ -49,4 +50,4 @@ class WorkPool
   def post(name, &block)
     fetch(name).post(&block)
   end
-end
+end end

--- a/lib/jarvis/workpool.rb
+++ b/lib/jarvis/workpool.rb
@@ -8,13 +8,22 @@ module Jarvis class WorkPool
   class InvalidWorkPoolName < Jarvis::Error; end
 
   class << self
-    def setup_singleton
-      @singleton = self.new
-      nil
+    INITIALIZER = Mutex.new
+
+    # Provide a singleton instance of WorkPool
+    #
+    # We don't use `include Singleton` because that disables `WorkPool.new` and
+    # makes this class very difficult to test. Practically, I don't want a
+    # global/singleton workpool anyway and this singleton instance only exists
+    # until we don't need it.
+    def instance
+      INITIALIZER.synchronize do
+        @instance ||= self.new
+      end
     end
 
     def fetch(name)
-      @singleton.fetch(name)
+      instance.fetch(name)
     end
 
     def post(name, &block)

--- a/lib/lita-jarvis.rb
+++ b/lib/lita-jarvis.rb
@@ -1,0 +1,12 @@
+require "lita"
+
+Lita.load_locales Dir[File.expand_path(
+  File.join("..", "..", "locales", "*.yml"), __FILE__
+)]
+
+require "lita/handlers/jarvis"
+
+Lita::Handlers::Jarvis.template_root File.expand_path(
+  File.join("..", "..", "templates"),
+ __FILE__
+)

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -9,11 +9,11 @@ module Lita
 
       on :loaded, :loaded
       def loaded(*args)
-        WorkPool.setup_singleton
+        ::Jarvis::WorkPool.setup_singleton
       end
 
       fancy_route("merge", ::Jarvis::Command::Merge, :command => true)
-      fancy_route("bounce", ::Jarvis::Command::Bounce, :command => true, :pool => WorkPool::ADMINISTRATIVE)
+      fancy_route("bounce", ::Jarvis::Command::Bounce, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
 
       Lita.register_handler(self)
     end

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -7,11 +7,6 @@ module Lita
     class Jarvis < Handler
       extend ::Jarvis::Mixins::FancyRoute
 
-      on :loaded, :loaded
-      def loaded(*args)
-        ::Jarvis::WorkPool.setup_singleton
-      end
-
       fancy_route("merge", ::Jarvis::Command::Merge, :command => true)
       fancy_route("bounce", ::Jarvis::Command::Bounce, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
 

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -1,0 +1,21 @@
+require "jarvis/commands/merge"
+require "jarvis/commands/bounce"
+require "jarvis/mixins/fancy_route"
+
+module Lita
+  module Handlers
+    class Jarvis < Handler
+      extend ::Jarvis::Mixins::FancyRoute
+
+      on :loaded, :loaded
+      def loaded(*args)
+        WorkPool.setup_singleton
+      end
+
+      fancy_route("merge", ::Jarvis::Command::Merge, :command => true)
+      fancy_route("bounce", ::Jarvis::Command::Bounce, :command => true, :pool => WorkPool::ADMINISTRATIVE)
+
+      Lita.register_handler(self)
+    end
+  end
+end

--- a/lita-jarvis.gemspec
+++ b/lita-jarvis.gemspec
@@ -1,0 +1,27 @@
+Gem::Specification.new do |spec|
+  spec.name          = "lita-jarvis"
+  spec.version       = "0.1.0"
+  spec.authors       = ["Jordan Sissel"]
+  spec.email         = ["jls@semicomplete.com"]
+  spec.description   = "TODO: Add a description"
+  spec.summary       = "TODO: Add a summary"
+  spec.homepage      = "TODO: Add a homepage"
+  spec.license       = "TODO: Add a license"
+  spec.metadata      = { "lita_plugin_type" => "handler" }
+
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "lita", ">= 4.6"
+  spec.add_runtime_dependency "clamp", "~> 1.0.0"
+
+  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "concurrent-ruby"
+  spec.add_development_dependency "pry-byebug"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rack-test"
+  spec.add_development_dependency "rspec", ">= 3.0.0"
+  spec.add_development_dependency "rspec-wait"
+end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,9 @@
+en:
+  lita:
+    handlers:
+      jarvis:
+        unhandled exception: >-
+          Unhandled exception: %{exception}
+        rejected execution: >-
+          The %{pool} pool is full, so I am too busy to do that work right now,
+          sorry!

--- a/spec/jarvis/clamp_delegate_spec.rb
+++ b/spec/jarvis/clamp_delegate_spec.rb
@@ -1,0 +1,51 @@
+require "jarvis/clamp_delegate"
+
+describe Jarvis::ClampDelegate do
+  let(:clamp) do
+    Class.new(Clamp::Command) do
+      option "--bar", :flag, "Set bar"
+      def execute; end
+    end
+  end
+
+  describe "#delegate" do
+    it "should return a proc" do
+      expect(described_class.delegate(clamp)).to be_a(Proc)
+    end
+  end
+
+  context "when the delegate is called" do
+    let(:request) { double() }
+    let(:message) { double() }
+    let(:delegate) { described_class.delegate(clamp) }
+
+    before do
+      expect(request).to receive(:message).and_return(message)
+      expect(message).to receive(:body).and_return(command_line_text)
+    end
+
+    context "with valid arguments" do
+      let(:command_line_text) { "foo --bar" }
+      it "should succeed" do
+        delegate.call(request)
+      end
+    end
+
+    context "with an invalid flag" do
+      let(:command_line_text) { "foo --invalid-flag" }
+      it "should reply with a failure message" do
+        expect(request).to receive(:reply).with(/Unrecognised option '--invalid-flag'/)
+        delegate.call(request)
+      end
+    end
+
+    context "with an invalid parameter" do
+      let(:command_line_text) { "foo param1" }
+      it "should reply with a failure message" do
+        expect(request).to receive(:reply).with(/^Error: too many arguments/)
+        delegate.call(request)
+      end
+    end
+  end
+
+end

--- a/spec/jarvis/workpool_spec.rb
+++ b/spec/jarvis/workpool_spec.rb
@@ -1,0 +1,78 @@
+require "jarvis/workpool"
+require "rspec/wait"
+
+describe WorkPool do
+  subject { described_class.new }
+
+  describe "#fetch" do
+    [ 1234, "invalid", "administrative", "", nil, false, true ].each do |name|
+      context "with #{name.inspect} (of type #{name.class})" do
+        it "raises WorkPool::InvalidWorkPoolName for an invalid pool name" do
+          expect { subject.fetch(name) }.to raise_error(WorkPool::InvalidWorkPoolName)
+        end
+      end
+    end
+
+    [WorkPool::ADMINISTRATIVE, WorkPool::NORMAL].each do |name|
+      context "with WorkPool::#{name}" do
+        it "should be successful " do
+          expect { subject.fetch(WorkPool::ADMINISTRATIVE) }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  describe "#post" do
+    [WorkPool::ADMINISTRATIVE, WorkPool::NORMAL].each do |pool|
+      context "on the #{pool} pool" do
+        context "and when the pool is not full" do
+          let(:queue) { Queue.new }
+          let(:value) { 1 }
+          it "should execute the block" do
+            subject.post(pool) { queue.push(value) }
+            wait(1).for { queue.pop(true) rescue nil }.to eq(value)
+          end
+        end
+
+        context "and when the pool is full" do
+          let(:value) { 1 }
+
+          let(:pool_size) { subject.fetch(pool).max_length + subject.fetch(pool).max_queue }
+
+          before do
+            # fill pool with blocked workers...
+            pool_size.times do
+              subject.post(pool) { sleep(60) }
+            end
+          end
+
+          it "should reject with an exception" do
+            expect do
+              subject.post(pool) { nil }
+            end.to raise_error(Concurrent::RejectedExecutionError)
+          end
+        end
+      end
+    end
+
+    context "on ADMINISTRATIVE when NORMAL is full" do
+      let(:normal) { subject.fetch(WorkPool::NORMAL) }
+      let(:value) { 1 }
+
+      let(:normal_pool_size) { normal.max_length + normal.max_queue }
+
+      before do
+        # fill pool with blocked workers...
+        normal_pool_size.times do
+          subject.post(WorkPool::NORMAL) { sleep(60) }
+        end
+      end
+
+      it "should succeed in posting" do
+        expect do
+          subject.post(WorkPool::ADMINISTRATIVE) { nil }
+        end.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/jarvis/workpool_spec.rb
+++ b/spec/jarvis/workpool_spec.rb
@@ -1,29 +1,29 @@
 require "jarvis/workpool"
 require "rspec/wait"
 
-describe WorkPool do
+describe ::Jarvis::WorkPool do
   subject { described_class.new }
 
   describe "#fetch" do
     [ 1234, "invalid", "administrative", "", nil, false, true ].each do |name|
       context "with #{name.inspect} (of type #{name.class})" do
-        it "raises WorkPool::InvalidWorkPoolName for an invalid pool name" do
-          expect { subject.fetch(name) }.to raise_error(WorkPool::InvalidWorkPoolName)
+        it "raises Jarvis::WorkPool::InvalidWorkPoolName for an invalid pool name" do
+          expect { subject.fetch(name) }.to raise_error(::Jarvis::WorkPool::InvalidWorkPoolName)
         end
       end
     end
 
-    [WorkPool::ADMINISTRATIVE, WorkPool::NORMAL].each do |name|
+    [::Jarvis::WorkPool::ADMINISTRATIVE, ::Jarvis::WorkPool::NORMAL].each do |name|
       context "with WorkPool::#{name}" do
         it "should be successful " do
-          expect { subject.fetch(WorkPool::ADMINISTRATIVE) }.not_to raise_error
+          expect { subject.fetch(::Jarvis::WorkPool::ADMINISTRATIVE) }.not_to raise_error
         end
       end
     end
   end
 
   describe "#post" do
-    [WorkPool::ADMINISTRATIVE, WorkPool::NORMAL].each do |pool|
+    [::Jarvis::WorkPool::ADMINISTRATIVE, ::Jarvis::WorkPool::NORMAL].each do |pool|
       context "on the #{pool} pool" do
         context "and when the pool is not full" do
           let(:queue) { Queue.new }
@@ -56,7 +56,7 @@ describe WorkPool do
     end
 
     context "on ADMINISTRATIVE when NORMAL is full" do
-      let(:normal) { subject.fetch(WorkPool::NORMAL) }
+      let(:normal) { subject.fetch(::Jarvis::WorkPool::NORMAL) }
       let(:value) { 1 }
 
       let(:normal_pool_size) { normal.max_length + normal.max_queue }
@@ -64,13 +64,13 @@ describe WorkPool do
       before do
         # fill pool with blocked workers...
         normal_pool_size.times do
-          subject.post(WorkPool::NORMAL) { sleep(60) }
+          subject.post(::Jarvis::WorkPool::NORMAL) { sleep(60) }
         end
       end
 
       it "should succeed in posting" do
         expect do
-          subject.post(WorkPool::ADMINISTRATIVE) { nil }
+          subject.post(::Jarvis::WorkPool::ADMINISTRATIVE) { nil }
         end.not_to raise_error
       end
     end

--- a/spec/lita/handlers/jarvis_spec.rb
+++ b/spec/lita/handlers/jarvis_spec.rb
@@ -1,0 +1,4 @@
+require "spec_helper"
+
+describe Lita::Handlers::Jarvis, lita_handler: true do
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require "lita-jarvis"
+require "lita/rspec"
+
+# A compatibility mode is provided for older plugins upgrading from Lita 3. Since this plugin
+# was generated with Lita 4, the compatibility mode should be left disabled.
+Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
There's a lot of work to do, but initial work in this PR is two main things:

1) Add work pools so that we can run multiple request simultaneously
2) Add an administrative pool in the event that Jarvis' main work pool is clogged with broken/stuck jobs
3) Add some integration between Clamp::Command and Lita handlers so that we can use Clamp's excellent APIs for writing chat commands.