### PR TITLE
Add lots of commands and improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+lita_config.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "lita-hipchat"
+#gem "lita-hipchat"
 gem "lita", git: "https://github.com/jordansissel/lita", branch: "user-metadata-deletes"
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-#gem "lita-hipchat", path: "#{File.dirname(__FILE__)}/../lita-hipchat"
+gem "lita-hipchat"
 gem "lita", git: "https://github.com/jordansissel/lita", branch: "user-metadata-deletes"
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
+gem "lita-hipchat"
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
-gem "lita", :path => "#{File.dirname(__FILE__)}/../lita"
+#gem "lita-hipchat", path: "#{File.dirname(__FILE__)}/../lita-hipchat"
+gem "lita", git: "https://github.com/jordansissel/lita", branch: "user-metadata-deletes"
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "lita-hipchat"
+gem "lita", :path => "#{File.dirname(__FILE__)}/../lita"
 gemspec

--- a/lib/jarvis/cla.rb
+++ b/lib/jarvis/cla.rb
@@ -1,0 +1,31 @@
+require "json"
+require "faraday"
+
+module Jarvis class CLA
+  def self.check(cla_url, repository, pr)
+    cla_uri = URI.parse(cla_url)
+    conn = Faraday.new(:url => "#{cla_uri.scheme}://#{cla_uri.host}")
+    conn.basic_auth(cla_uri.user, cla_uri.password)
+    response = conn.get(cla_uri.path, :repository => repository, :number => pr)
+    check = JSON.parse(response.body)
+    # TODO(sissel): json exception? .get exception?
+
+    return self.new(check["status"] == "success", check["message"])
+  end
+
+  private
+  def initialize(ok, message)
+    @ok = ok
+    @message = message
+  end
+
+  # The message indicating whatever reason for the success (or failed) CLA check
+  attr_reader :message
+
+  # Was this check successful?
+  def ok?
+    return @ok
+  end
+
+  public(:ok?, :message)
+end end

--- a/lib/jarvis/clamp_delegate.rb
+++ b/lib/jarvis/clamp_delegate.rb
@@ -13,18 +13,41 @@ module Jarvis module ClampDelegate
   # The 'foo' command, when invoked via the Lita bot, will pass the whole
   # message body into the Foo clamp command as if it were run via the command
   # line.
-  def self.delegate(command_class)
+  def self.delegate(command_class, options)
     if !command_class.ancestors.include?(Clamp::Command)
       raise ArgumentError, "Cannot delegate to `#{command_class}` because it is not a subclass of Clamp::Command"
     end
-    callback(command_class)
+    callback(command_class, options)
   end
 
   private
-  def self.callback(command_class)
+  def self.callback(command_class, options)
+    if options.include?(:flags) 
+      if !options[:flags].is_a?(Hash) 
+        raise ArgumentError, ":flags option to #{command_class} must be a Hash of { \"--string-flag\" => lambda { |x| ... } }"
+      end
+      if !options[:flags].all? { |k,v| k.is_a?(String) && v.is_a?(Proc) }
+        raise ArgumentError, ":flags option to #{command_class} must be a Hash of { \"--string-flag\" => lambda { |x| ... } }"
+      end
+      if !options[:flags].all? { |k,_| k =~ /^--/ }
+        raise ArgumentError, ":flags keys must all be string starting with '--', like { \"--example\" => lambda { |x| ... } }"
+      end
+    end
+
     lambda do |request|
       name, *args = Shellwords.shellsplit(request.message.body)
       cmd = command_class.new(name)
+
+      if options.include?(:flags)
+        # prepend flags to the args
+        # The `:flags` value is expected to be a Hash of "--flag-name" => lambda { |request| ... }
+        # The idea is that there can be automatic flags based on the
+        # circumstances of the request.
+        options[:flags].each do |key, value_proc|
+          value = value_proc.call(request)
+          args.unshift(key, value) if value
+        end
+      end
 
       inject_methods(cmd, request)
 

--- a/lib/jarvis/clamp_delegate.rb
+++ b/lib/jarvis/clamp_delegate.rb
@@ -65,11 +65,11 @@ module Jarvis module ClampDelegate
   def self.inject_methods(obj, request)
     # Override `puts` and `p` calls from within `obj` to cause them to reply
     # instead of printing to stdout.
-    obj.define_singleton_method(:puts) do |message|
-      request.reply(message)
+    obj.define_singleton_method(:puts) do |*args|
+      request.reply(args.collect(&:to_s))
     end
-    obj.define_singleton_method(:p) do |message|
-      request.reply(message.inspect)
+    obj.define_singleton_method(:p) do |*args|
+      request.reply(args.collect(&:inspect))
     end
   end
 end end

--- a/lib/jarvis/clamp_delegate.rb
+++ b/lib/jarvis/clamp_delegate.rb
@@ -66,10 +66,10 @@ module Jarvis module ClampDelegate
     # Override `puts` and `p` calls from within `obj` to cause them to reply
     # instead of printing to stdout.
     obj.define_singleton_method(:puts) do |*args|
-      request.reply(args.collect(&:to_s))
+      request.reply(*args.collect(&:to_s))
     end
     obj.define_singleton_method(:p) do |*args|
-      request.reply(args.collect(&:inspect))
+      request.reply(*args.collect(&:inspect))
     end
   end
 end end

--- a/lib/jarvis/commands/cla.rb
+++ b/lib/jarvis/commands/cla.rb
@@ -1,0 +1,28 @@
+require "clamp"
+require "jarvis/cla"
+require "i18n"
+
+module Jarvis module Command class CLA < Clamp::Command
+  def t(key, params={})
+    I18n.t("lita.handlers.jarvis.#{key}", params)
+  end
+
+  banner "Run a CLA check on a PR"
+
+  option "--cla-url", "CLA_URL", "The URL for the CLA check service", :required => true, :environment_variable => "JARVIS_CLA_URL"
+
+  parameter "URL", "The PR URL to check"
+
+  def execute
+    *_, user, project, _, pr = url.split("/")
+    cla = ::Jarvis::CLA.check(cla_url, "#{user}/#{project}", pr.to_i)
+    if cla.ok?
+      puts t("cla.success", :project => "#{user}/#{project}", :pr => pr, :message => cla.message)
+    else
+      puts t("cla.failure", :project => "#{user}/#{project}", :pr => pr, :message => cla.message)
+      return 1
+    end
+  rescue => e
+    puts "An error occurred: #{e.class} - #{e}\n" + e.backtrace.join("\n")
+  end
+end end end

--- a/lib/jarvis/commands/cla.rb
+++ b/lib/jarvis/commands/cla.rb
@@ -3,10 +3,6 @@ require "jarvis/cla"
 require "i18n"
 
 module Jarvis module Command class CLA < Clamp::Command
-  def t(key, params={})
-    I18n.t("lita.handlers.jarvis.#{key}", params)
-  end
-
   banner "Run a CLA check on a PR"
 
   option "--cla-url", "CLA_URL", "The URL for the CLA check service", :required => true, :environment_variable => "JARVIS_CLA_URL"
@@ -17,9 +13,9 @@ module Jarvis module Command class CLA < Clamp::Command
     *_, user, project, _, pr = url.split("/")
     cla = ::Jarvis::CLA.check(cla_url, "#{user}/#{project}", pr.to_i)
     if cla.ok?
-      puts t("cla.success", :project => "#{user}/#{project}", :pr => pr, :message => cla.message)
+      puts I18n.t("lita.handlers.jarvis.cla.success", :project => "#{user}/#{project}", :pr => pr, :message => cla.message)
     else
-      puts t("cla.failure", :project => "#{user}/#{project}", :pr => pr, :message => cla.message)
+      puts I18n.t("lita.handlers.jarvis.cla.failure", :project => "#{user}/#{project}", :pr => pr, :message => cla.message)
       return 1
     end
   rescue => e

--- a/lib/jarvis/commands/merge.rb
+++ b/lib/jarvis/commands/merge.rb
@@ -13,6 +13,7 @@ module Jarvis module Command class Merge < Clamp::Command
 
   def execute
     puts "This merge command does nothing, yet!"
+    puts "I will use #{committer} as the committer"
     # Fetch the .patch
     # Clone the git repo
     # Merge the patch

--- a/lib/jarvis/commands/merge.rb
+++ b/lib/jarvis/commands/merge.rb
@@ -1,15 +1,24 @@
 require "clamp"
 require "i18n"
+require "git"
 
 module Jarvis module Command class Merge < Clamp::Command
 
   banner "Merge a pull request into one or more branches."
 
+  option "--committer", "COMMITTER", "The git committer to set on all commits. If not set, the default is whatever your git defaults to (see `git config --get user.name` and `git config --get user.email`)."
+
   parameter "URL", "The URL to merge"
   parameter "BRANCHES ...", "The branches to merge"
 
   def execute
-    puts "Merging: #{url} into #{branches_list}"
+    puts "This merge command does nothing, yet!"
+    # Fetch the .patch
+    # Clone the git repo
+    # Merge the patch
+    # Modify commit messages
+    # Push to branches
+    # Set labels on PRs
   rescue => e
     puts I18n.t("lita.handlers.jarvis.exception", :exception => e.class, :message => e.to_s, :stacktrace => e.backtrace.join("\n"), :command => "merge")
   end

--- a/lib/jarvis/commands/merge.rb
+++ b/lib/jarvis/commands/merge.rb
@@ -1,4 +1,6 @@
 require "clamp"
+require "octokit"
+require "mustache"
 require "open4"
 require "cabin"
 require "i18n"
@@ -19,12 +21,21 @@ module Jarvis module Command class Merge < Clamp::Command
   option "--committer-name", "NAME", "The git committer name to set on all commits. If not set, the default is whatever your git defaults to (see `git config --get user.name` and `git config --get user.email`)."
 
   option "--workdir", "WORKDIR", "The place where this command will download temporary files and do stuff on disk to complete a given task."
+  option "--github-token", "GITHUB_TOKEN", "Your github auth token", :required => true
 
   parameter "URL", "The URL to merge"
   parameter "BRANCHES ...", "The branches to merge", :attribute_name => :branches
 
   def pr
     @pr ||= Jarvis::GitHub::PullRequest.parse(url)
+  end
+
+  def github
+    return @github if @github
+    @github = Octokit::Client.new
+    @github.access_token = github_token
+    @github.login
+    @github
   end
 
   def execute
@@ -55,11 +66,13 @@ module Jarvis module Command class Merge < Clamp::Command
     Jarvis::Git.config(git, "user.email", committer_email)
     Jarvis::Git.config(git, "user.name", committer_name)
 
+    commits = []
     branches.each do |branch|
       logger[:branch] = branch
       logger.info("Working on a branch")
       git.checkout(branch)
 
+      commits << { :branch => branch, :commits => [] }
       patches = Mbox.new(patch_file)
       patches.each do |mail|
         ::Jarvis::Git.apply_mail(git, mail, logger) do |description|
@@ -67,10 +80,18 @@ module Jarvis module Command class Merge < Clamp::Command
           # whatever PR this is..
           description + "\nFixes \##{pr.number}"
         end
-        logger.info("Patch successfully applied")
+
+        # Record the commit hash for this commit.
+        commits.last[:commits] << git.revparse("HEAD") 
       end
+      logger.info("Patch successfully applied")
       logger[:branch] = nil
     end
+
+    template = File.join(File.dirname(__FILE__), "..", "..", "..", "templates", "github_merge_comment.mustache")
+    comment = Mustache.render(File.read(template),
+                              :committer => committer_name,
+                              :commits => commits.each { |v| v[:commits] = v[:commits].join(", ") })
 
     # Push to branches
     logger[:operation] = "git push"
@@ -80,10 +101,12 @@ module Jarvis module Command class Merge < Clamp::Command
     _, status = Process::waitpid2(pid)
     raise PushFailure, "git push failed" unless status.success?
 
-    puts I18n.t("lita.handlers.jarvis.merge success", organization: pr.organization, project: pr.project, number: pr.number, branches: branches.join(","))
+    logger[:operation]  = "add comment"
+    logger.info("Adding comment to issue")
+    github.add_comment("#{pr.organization}/#{pr.project}", pr.number, comment)
 
     # TODO(sissel): Set labels on PRs
-    # TODO(sissel): Comment on PR
+    puts I18n.t("lita.handlers.jarvis.merge success", organization: pr.organization, project: pr.project, number: pr.number, branches: branches.join(","))
   rescue => e
     puts I18n.t("lita.handlers.jarvis.exception", :exception => e.class, :message => e.to_s, :stacktrace => e.backtrace.join("\n"), :command => "merge", :logs => logs.join("\n"))
   ensure

--- a/lib/jarvis/commands/merge.rb
+++ b/lib/jarvis/commands/merge.rb
@@ -33,6 +33,7 @@ module Jarvis module Command class Merge < Clamp::Command
     logger.subscribe(logs)
     logger.subscribe(STDOUT) if STDOUT.tty?
     logger.level = :debug
+    logger[:context] = "#{pr.project}\##{pr.number}"
 
     self.workdir = Stud::Temporary.pathname if workdir.nil?
 
@@ -49,8 +50,9 @@ module Jarvis module Command class Merge < Clamp::Command
 
     # ruby Git library doesn't seem to support setting per-repo configuration,
     # so we call `git` directly.
+    logger.info("Setting local git committer details", :email => committer_email, :name => committer_name)
     system("git", "-C", git.dir.to_s, "config", "user.email", committer_email)
-    system("git", "-C", git.dir.to_s, "config", "user.email", committer_name)
+    system("git", "-C", git.dir.to_s, "config", "user.name", committer_name)
 
     branches.each do |branch|
       logger[:branch] = branch

--- a/lib/jarvis/commands/merge.rb
+++ b/lib/jarvis/commands/merge.rb
@@ -52,8 +52,8 @@ module Jarvis module Command class Merge < Clamp::Command
     # ruby Git library doesn't seem to support setting per-repo configuration,
     # so we call `git` directly.
     logger.info("Setting local git committer details", :email => committer_email, :name => committer_name)
-    system("git", "-C", git.dir.to_s, "config", "user.email", committer_email)
-    system("git", "-C", git.dir.to_s, "config", "user.name", committer_name)
+    Jarvis::Git.config(git, "user.email", committer_email)
+    Jarvis::Git.config(git, "user.name", committer_name)
 
     branches.each do |branch|
       logger[:branch] = branch

--- a/lib/jarvis/commands/merge.rb
+++ b/lib/jarvis/commands/merge.rb
@@ -1,4 +1,5 @@
 require "clamp"
+require "i18n"
 
 module Jarvis module Command class Merge < Clamp::Command
 
@@ -10,6 +11,6 @@ module Jarvis module Command class Merge < Clamp::Command
   def execute
     puts "Merging: #{url} into #{branches_list}"
   rescue => e
-    puts "An error occurred: #{e.class} - #{e}\n" + e.backtrace.join("\n")
+    puts I18n.t("lita.handlers.jarvis.exception", :exception => e.class, :message => e.to_s, :stacktrace => e.backtrace.join("\n"), :command => "merge")
   end
 end end end

--- a/lib/jarvis/commands/merge.rb
+++ b/lib/jarvis/commands/merge.rb
@@ -1,4 +1,5 @@
 require "clamp"
+require "fileutils"
 require "octokit"
 require "mustache"
 require "open4"
@@ -48,8 +49,10 @@ module Jarvis module Command class Merge < Clamp::Command
     logger.level = :debug
     logger[:context] = "#{pr.project}\##{pr.number}"
 
-    self.workdir = Stud::Temporary.pathname if workdir.nil?
-
+    if workdir.nil?
+      self.workdir = Stud::Temporary.pathname
+      defer.do { FileUtils.rm_r(workdir, :secure => true) }
+    end
     Dir.mkdir(workdir) unless File.directory?(workdir)
 
     # Download the patch

--- a/lib/jarvis/commands/merge.rb
+++ b/lib/jarvis/commands/merge.rb
@@ -1,26 +1,90 @@
 require "clamp"
+require "open4"
+require "cabin"
 require "i18n"
 require "git"
+require "stud/temporary"
+require "jarvis/github/pull_request"
+require "jarvis/git"
+require "jarvis/fetch"
+require "mbox"
 
 module Jarvis module Command class Merge < Clamp::Command
+  class PushFailure < ::Jarvis::Error; end
 
   banner "Merge a pull request into one or more branches."
 
-  option "--committer", "COMMITTER", "The git committer to set on all commits. If not set, the default is whatever your git defaults to (see `git config --get user.name` and `git config --get user.email`)."
+  option "--committer-email", "EMAIL", "The git committer to set on all commits. If not set, the default is whatever your git defaults to (see `git config --get user.email` and `git config --get user.email`)."
+  option "--committer-name", "NAME", "The git committer name to set on all commits. If not set, the default is whatever your git defaults to (see `git config --get user.name` and `git config --get user.email`)."
+
+  option "--workdir", "WORKDIR", "The place where this command will download temporary files and do stuff on disk to complete a given task."
 
   parameter "URL", "The URL to merge"
-  parameter "BRANCHES ...", "The branches to merge"
+  parameter "BRANCHES ...", "The branches to merge", :attribute_name => :branches
+
+  def pr
+    @pr ||= Jarvis::GitHub::PullRequest.parse(url)
+  end
 
   def execute
-    puts "This merge command does nothing, yet!"
-    puts "I will use #{committer} as the committer"
-    # Fetch the .patch
+    cleanup = []
+    logs = []
+    logger = ::Cabin::Channel.new
+    logger.subscribe(logs)
+    logger.subscribe(STDOUT) if STDOUT.tty?
+    logger.level = :debug
+
+    self.workdir = Stud::Temporary.pathname if workdir.nil?
+
+    Dir.mkdir(workdir) unless File.directory?(workdir)
+
+    # Download the patch
+    logger.info("Fetching PR", :url => pr.patch_url)
+    patch_file = Jarvis::Fetch.file(pr.patch_url)
+    cleanup << patch_file.path
+
     # Clone the git repo
-    # Merge the patch
-    # Modify commit messages
+    logger.info("Cloning repo", :url => pr.git_url)
+    git = Jarvis::Git.clone_repo(pr.git_url, workdir)
+
+    # ruby Git library doesn't seem to support setting per-repo configuration,
+    # so we call `git` directly.
+    system("git", "-C", git.dir.to_s, "config", "user.email", committer_email)
+    system("git", "-C", git.dir.to_s, "config", "user.email", committer_name)
+
+    branches.each do |branch|
+      logger[:branch] = branch
+      logger.info("Working on a branch")
+      git.checkout(branch)
+
+      patches = Mbox.new(patch_file)
+      patches.each do |mail|
+        ::Jarvis::Git.apply_mail(git, mail, logger) do |description|
+          # Append the 'Fixes #1234' to the bottom of the commit message for
+          # whatever PR this is..
+          description + "\nFixes \##{pr.number}"
+        end
+        logger.info("Patch successfully applied")
+      end
+      logger[:branch] = nil
+    end
+
     # Push to branches
+    logger[:operation] = "git push"
+    pid, stdin, stdout, stderr = Open4::popen4("git", "-C", "#{git.dir}", "push", "origin", *branches)
+    stdin.close
+    logger.pipe(stdout => :info, stderr => :error)
+    _, status = Process::waitpid2(pid)
+    raise PushFailure, "git push failed" unless status.success?
+
     # Set labels on PRs
+    puts I18n.t("lita.handlers.jarvis.merge success", organization: pr.organization, project: pr.project, number: pr.number, branches: branches.join(","))
   rescue => e
-    puts I18n.t("lita.handlers.jarvis.exception", :exception => e.class, :message => e.to_s, :stacktrace => e.backtrace.join("\n"), :command => "merge")
+    puts I18n.t("lita.handlers.jarvis.exception", :exception => e.class, :message => e.to_s, :stacktrace => e.backtrace.join("\n"), :command => "merge", :logs => logs.join("\n"))
+  ensure
+    cleanup.each do |path|
+      File.unlink(path)
+    end
   end
+
 end end end

--- a/lib/jarvis/commands/ping.rb
+++ b/lib/jarvis/commands/ping.rb
@@ -1,0 +1,7 @@
+require "clamp"
+
+module Jarvis module Command class Ping < Clamp::Command
+  def execute
+    puts I18n.t("lita.handlers.jarvis.ping response")
+  end
+end end end

--- a/lib/jarvis/commands/ping.rb
+++ b/lib/jarvis/commands/ping.rb
@@ -1,4 +1,5 @@
 require "clamp"
+require "i18n"
 
 module Jarvis module Command class Ping < Clamp::Command
   def execute

--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -24,7 +24,7 @@ module Jarvis module Command class Publish < Clamp::Command
     logs = []
     logger = ::Cabin::Channel.new
     logger.subscribe(logs)
-    logger.subscribe(STDOUT) if STDOUT.tty?
+    logger.subscribe(STDOUT)
     logger.level = :debug
 
     logger.info("Cloning repo", :url => project.git_url)

--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -39,7 +39,7 @@ module Jarvis module Command class Publish < Clamp::Command
 
       TASKS.each do |command|
         context[:command] = command
-        Jarvis.execute(Shellwords.shellsplit(command), logger)
+        Jarvis.execute(command, logger, git.dir)
       end
       context.clear()
       git.reset
@@ -48,6 +48,6 @@ module Jarvis module Command class Publish < Clamp::Command
 
     puts I18n.t("lita.handlers.jarvis.publish success", organization: project.organization, project: project.name, branches: branches.join(", "))
   rescue => e
-    puts I18n.t("lita.handlers.jarvis.exception", :exception => e.class, :message => e.to_s, :stacktrace => e.backtrace.join("\n"), :command => "merge", :logs => logs.join("\n"))
+    puts I18n.t("lita.handlers.jarvis.exception", :exception => e.class, :message => e.to_s, :stacktrace => e.backtrace.join("\n"), :command => "merge", :logs => logs.collect { |l| l[:message] }.join("\n"))
   end
 end end end

--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -1,0 +1,53 @@
+require "clamp"
+require "i18n"
+require "stud/temporary"
+require "jarvis/exec"
+require "jarvis/github/project"
+
+module Jarvis module Command class Publish < Clamp::Command
+  banner "Publish a logstash plugin"
+
+  option "--committer-email", "EMAIL", "The git committer to set on all commits. If not set, the default is whatever your git defaults to (see `git config --get user.email` and `git config --get user.email`)."
+  option "--committer-name", "NAME", "The git committer name to set on all commits. If not set, the default is whatever your git defaults to (see `git config --get user.name` and `git config --get user.email`)."
+  option "--workdir", "WORKDIR", "The place where this command will download temporary files and do stuff on disk to complete a given task."
+  option "--github-token", "GITHUB_TOKEN", "Your github auth token", :required => true
+
+  parameter "PROJECT", "The project URL" do |url|
+    Jarvis::GitHub::Project.parse(url)
+  end
+  parameter "[BRANCH] ...", "The branches to publish", :default => [ "master" ], :attribute_name => "branches"
+
+  TASKS = [ 'bundle install', 'bundle exec rake vendor', 'bundle exec rake publish_gem' ].freeze
+  def execute
+    self.workdir = Stud::Temporary.pathname if workdir.nil?
+
+    logs = []
+    logger = ::Cabin::Channel.new
+    logger.subscribe(logs)
+    logger.subscribe(STDOUT) if STDOUT.tty?
+    logger.level = :debug
+
+    logger.info("Cloning repo", :url => project.git_url)
+    git = Jarvis::Git.clone_repo(project.git_url, workdir)
+
+    branches.each do |branch|
+      logger.info("Switching branches", :branch => branch)
+      git.checkout(branch)
+      context = logger.context
+      context[:operation] = "publish"
+      context[:branch] = branch
+
+      TASKS.each do |command|
+        context[:command] = command
+        Jarvis.execute(Shellwords.shellsplit(command), logger)
+      end
+      context.clear()
+      git.reset
+      git.clean(force: true)
+    end
+
+    puts I18n.t("lita.handlers.jarvis.publish success", organization: project.organization, project: project.name, branches: branches.join(", "))
+  rescue => e
+    puts I18n.t("lita.handlers.jarvis.exception", :exception => e.class, :message => e.to_s, :stacktrace => e.backtrace.join("\n"), :command => "merge", :logs => logs.join("\n"))
+  end
+end end end

--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -25,7 +25,7 @@ module Jarvis module Command class Publish < Clamp::Command
     logger = ::Cabin::Channel.new
     logger.subscribe(logs)
     logger.subscribe(STDOUT)
-    logger.level = :debug
+    logger.level = :info
 
     logger.info("Cloning repo", :url => project.git_url)
     git = Jarvis::Git.clone_repo(project.git_url, workdir)
@@ -40,6 +40,9 @@ module Jarvis module Command class Publish < Clamp::Command
       TASKS.each do |command|
         context[:command] = command
         Jarvis.execute(command, logger, git.dir)
+
+        # Clear the logs if it was successful
+        logs.clear unless logger.debug?
       end
       context.clear()
       git.reset

--- a/lib/jarvis/defer.rb
+++ b/lib/jarvis/defer.rb
@@ -1,0 +1,15 @@
+module Jarvis class Defer
+  def initialize
+    @deferred = []
+  end
+
+  def do(&block)
+    @deferred << block
+  end
+
+  def run
+    @deferred.each do |block|
+      block.call
+    end
+  end
+end end

--- a/lib/jarvis/error.rb
+++ b/lib/jarvis/error.rb
@@ -1,2 +1,4 @@
-module Jarvis class Error < StandardError 
-end end
+module Jarvis 
+  class Error < StandardError ; end
+  class UserProfileError < StandardError ; end
+end

--- a/lib/jarvis/exec.rb
+++ b/lib/jarvis/exec.rb
@@ -6,10 +6,10 @@ module Jarvis
 
   def self.execute(args, logger)
     logger.info("Running command", :args => args)
-    #pid, stdin, stdout, stderr = Open4::popen4(*args)
-    #stdin.close
-    #logger.pipe(stdout => :info, stderr => :error)
-    #_, status = Process::waitpid2(pid)
-    #raise SubprocessFailure, "subprocess failed with code #{status.exitstatus}" unless status.success?
+    pid, stdin, stdout, stderr = Open4::popen4(*args)
+    stdin.close
+    logger.pipe(stdout => :info, stderr => :error)
+    _, status = Process::waitpid2(pid)
+    raise SubprocessFailure, "subprocess failed with code #{status.exitstatus}" unless status.success?
   end
 end

--- a/lib/jarvis/exec.rb
+++ b/lib/jarvis/exec.rb
@@ -1,12 +1,18 @@
 require "jarvis/error"
-require "open4"
+require "shellwords"
 
 module Jarvis
   class SubprocessFailure < ::Jarvis::Error ; end
+  JRUBY_VERSION = "1.7.22"
 
-  def self.execute(args, logger)
+  def self.execute(args, logger, directory=nil)
     logger.info("Running command", :args => args)
-    pid, stdin, stdout, stderr = Open4::popen4(*args)
+    pid, stdin, stdout, stderr = if directory
+       wrapped = ["env", "-", "PATH=#{ENV["PATH"]}", "HOME=#{ENV["HOME"]}", "bash", "-c", "cd #{Shellwords.shellescape(directory)};. ~/.rvm/scripts/rvm; echo PWD; pwd; rvm use #{JRUBY_VERSION}; rvm use; #{args}"]
+      Open4::popen4(*wrapped)
+    else
+      Open4::popen4(*args)
+    end
     stdin.close
     logger.pipe(stdout => :info, stderr => :error)
     _, status = Process::waitpid2(pid)

--- a/lib/jarvis/exec.rb
+++ b/lib/jarvis/exec.rb
@@ -1,0 +1,15 @@
+require "jarvis/error"
+require "open4"
+
+module Jarvis
+  class SubprocessFailure < ::Jarvis::Error ; end
+
+  def self.execute(args, logger)
+    logger.info("Running command", :args => args)
+    #pid, stdin, stdout, stderr = Open4::popen4(*args)
+    #stdin.close
+    #logger.pipe(stdout => :info, stderr => :error)
+    #_, status = Process::waitpid2(pid)
+    #raise SubprocessFailure, "subprocess failed with code #{status.exitstatus}" unless status.success?
+  end
+end

--- a/lib/jarvis/fetch.rb
+++ b/lib/jarvis/fetch.rb
@@ -1,0 +1,30 @@
+require "jarvis/error"
+require "faraday"
+require "faraday_middleware"
+
+module Jarvis module Fetch
+  class DownloadFailure < ::Jarvis::Error; end
+  def self.file(url)
+    url = URI.parse(url) if url.is_a?(String)
+    file = Stud::Temporary.file
+
+    # TODO(sissel): timeout + retry
+    http = Faraday.new do |conn|
+      conn.use FaradayMiddleware::FollowRedirects
+      conn.adapter :net_http
+    end
+
+    response = http.get(url)
+
+    if response.status != 200
+      require "pry"; binding.pry
+      raise DownloadFailure, "Got HTTP #{response.status} when fetching #{url}"
+    end
+
+    file.write(response.body)
+    file.flush
+    file.rewind
+
+    file
+  end
+end end

--- a/lib/jarvis/git.rb
+++ b/lib/jarvis/git.rb
@@ -52,4 +52,9 @@ module Jarvis module Git
       File.unlink(path)
     end
   end
+
+  def self.config(git, key, value)
+    # ruby Git doesn't support this, so we do it ourselves.
+    system("git", "-C", git.dir.to_s, "config", key, value)
+  end
 end end

--- a/lib/jarvis/git.rb
+++ b/lib/jarvis/git.rb
@@ -1,0 +1,55 @@
+require "git"
+require "jarvis/error"
+
+module Jarvis module Git
+  class MergeProblem < ::Jarvis::Error; end
+  PATCH_MESSAGE_SEPARATOR = "---\n"
+
+  # Returns a Git::Base after cloning the repo
+  def self.clone_repo(git_url, workdir)
+    name = git_url.split("/").last.gsub(/\.git$/, "")
+    ::Git.clone(git_url, name, :path => workdir)
+  end
+
+  # Apply a mail-format patch to a git repo.
+  #
+  # - git: a Git::Base (from Git.init, Git.clone, etc)
+  # - mail: a Mbox::Mail instance
+  # - logger: a Cabin::Channel
+  # - &block: optional. If provided, will be passed the commit description as
+  #   the only argument. The return value will be used as the new description.
+  def self.apply_mail(git, mail, logger, &block)
+    cleanup = []
+    # github prefixes the subject line with [PATCH], remove that part.
+    subject = mail.headers[:subject].gsub(/^\[PATCH\] /, "")
+    logger.info("Working on a patch", :subject => subject)
+    # The email body (minus the patch itself) is the rest of the commit message
+    description, diff = mail.content.first.content.split(PATCH_MESSAGE_SEPARATOR, 2)
+    
+    if subject.empty? && description.empty?
+      raise MergeProblem, "Subject or description in a commit cannot be empty. Aborting merge attempt."
+    end
+
+    description = block.call(description) if block_given?
+    patch = Stud::Temporary.file
+    cleanup << patch.path
+    # Patches must have a trailing newline
+    patch.write([mail.headers.to_s, description, PATCH_MESSAGE_SEPARATOR, diff, ""].join("\n"))
+    patch.close
+
+    # We have to use system() here because the ruby Git library fails due to requiring chdir first.
+    # If we chdir, we cannot do multiple git actions simultaneously. 
+    logger.info("Applying patch")
+    pid, stdin, stdout, stderr = Open4::popen4("git", "-C", "#{git.dir}", "am", "--", patch.path)
+    stdin.close
+    logger.pipe(stdout => :info, stderr => :error)
+
+    # Wait for the `git am` subprocess to finish.
+    _, status = Process::waitpid2(pid)
+    raise MergeProblem, "Merging patch failed. Aborting." unless status.success?
+  ensure
+    cleanup.each do |path|
+      File.unlink(path)
+    end
+  end
+end end

--- a/lib/jarvis/github/project.rb
+++ b/lib/jarvis/github/project.rb
@@ -1,0 +1,27 @@
+require "jarvis/error"
+
+module Jarvis module GitHub class Project
+  class InvalidURL < ::Jarvis::Error; end
+  def self.parse(url)
+    uri = URI.parse(url)
+    _, organization, name, *_ = uri.path.split("/")
+    if organization.nil?
+      raise InvalidURL, "Could not find the organization in the url"
+    end
+    if name.nil?
+      raise InvalidURL, "Could not find the name in the url"
+    end
+    return self.new(organization, name)
+  end
+
+  attr_reader :organization, :name
+
+  def initialize(organization, name)
+    @organization = organization
+    @name = name
+  end
+
+  def git_url
+    return "https://github.com/#{@organization}/#{@name}"
+  end
+end end end

--- a/lib/jarvis/github/pull_request.rb
+++ b/lib/jarvis/github/pull_request.rb
@@ -2,6 +2,8 @@ require "jarvis/error"
 
 module Jarvis module GitHub class PullRequest
   class InvalidURL < ::Jarvis::Error; end
+  BASE_URL = "https://github.com"
+
   def self.parse(url)
     url = URI.parse(url) if url.is_a?(String)
 
@@ -17,5 +19,18 @@ module Jarvis module GitHub class PullRequest
 
   def to_s
     "https://github.com/#{organization}/#{project}/pull/#{number}"
+  end
+
+  def repository_url
+    [BASE_URL, organization, project].join("/")
+  end
+
+  def git_url
+    #repository_url + ".git"
+    "git@github.com:/#{organization}/#{project}.git"
+  end
+
+  def patch_url
+    to_s + ".patch"
   end
 end end end

--- a/lib/jarvis/github/pull_request.rb
+++ b/lib/jarvis/github/pull_request.rb
@@ -1,0 +1,21 @@
+require "jarvis/error"
+
+module Jarvis module GitHub class PullRequest
+  class InvalidURL < ::Jarvis::Error; end
+  def self.parse(url)
+    url = URI.parse(url) if url.is_a?(String)
+
+    pr = self.new
+    _, pr.organization, pr.project, type, pr.number, *remaining = url.path.split("/")
+    if type != "pull" || remaining.any? || pr.organization.nil? || pr.project.nil? || pr.number.nil? || pr.number !~ /^\d+$/
+      raise InvalidURL, "Not a valid GitHub pull request URL: #{url}"
+    end
+    pr
+  end
+
+  attr_accessor :organization, :project, :number
+
+  def to_s
+    "https://github.com/#{organization}/#{project}/pull/#{number}"
+  end
+end end end

--- a/lib/jarvis/mixins/fancy_route.rb
+++ b/lib/jarvis/mixins/fancy_route.rb
@@ -11,7 +11,7 @@ module Jarvis module Mixins module FancyRoute
       options[:help] = { pattern => handler.description || "#{pattern} #{handler.derived_usage_description}" }
     end
 
-    handler = fancy_handler(handler, &block)
+    handler = fancy_handler(handler, options, &block)
 
     # Turn a string "foo" into a regexp /^foo(\s|$)/
     pattern = Regexp.new("^#{Regexp.escape(pattern)}(\\s|$)") if pattern.is_a?(String)
@@ -23,7 +23,7 @@ module Jarvis module Mixins module FancyRoute
     route(pattern, options, &pool_delegate(pool, &handler))
   end
 
-  def fancy_handler(handler, &block)
+  def fancy_handler(handler, options, &block)
     if handler.nil?
       raise "Nothing to route to - no block or handler given for #{regexp} route." if block.nil?
 
@@ -38,7 +38,7 @@ module Jarvis module Mixins module FancyRoute
       # nothing needed to be done
     when Class
       if handler.ancestors.include?(::Clamp::Command)
-        handler = ::Jarvis::ClampDelegate.delegate(handler)
+        handler = ::Jarvis::ClampDelegate.delegate(handler, options)
       end
     else
       raise "Unsupported handler type #{handler.class} (#{handler.inspect})"

--- a/lib/jarvis/mixins/pool_delegate.rb
+++ b/lib/jarvis/mixins/pool_delegate.rb
@@ -15,7 +15,7 @@ module Jarvis module Mixins module PoolDelegate
       begin
         callback_proc.call(request)
       rescue ::Jarvis::UserProfileError => e
-        request.reply(t("user profile error", :user => request.user.name, :class => e.class, :message => e.message))
+        request.reply(t("user profile error", :user => request.user.mention_name, :class => e.class, :message => e.message))
       rescue => e
         # TODO(sissel): Mark this job as failed
         request.reply(t("unhandled exception", :class => e.class, :message => e.message))

--- a/lib/jarvis/mixins/pool_delegate.rb
+++ b/lib/jarvis/mixins/pool_delegate.rb
@@ -14,9 +14,11 @@ module Jarvis module Mixins module PoolDelegate
       # TODO(sissel): Redirect $stdout and $stderr?
       begin
         callback_proc.call(request)
+      rescue ::Jarvis::UserProfileError => e
+        request.reply(t("user profile error", :user => request.user.name, :class => e.class, :message => e.message))
       rescue => e
         # TODO(sissel): Mark this job as failed
-        request.reply(t("unhandled exception", :exception => e))
+        request.reply(t("unhandled exception", :class => e.class, :message => e.message))
         request.reply(e.backtrace.join("\n"))
       end
       # TODO(sissel): Mark this job as complete. (Once we have job/command tracking)
@@ -24,6 +26,6 @@ module Jarvis module Mixins module PoolDelegate
   rescue Concurrent::RejectedExecutionError => e
     request.reply(t("rejected execution", :pool => pool_name))
   rescue => e
-    request.reply(t("unhandled exception", :exception => e))
+    request.reply(t("unhandled exception", :class => e.class, :message => e.message))
   end
 end end end

--- a/lib/jarvis/mixins/pool_delegate.rb
+++ b/lib/jarvis/mixins/pool_delegate.rb
@@ -15,17 +15,17 @@ module Jarvis module Mixins module PoolDelegate
       begin
         callback_proc.call(request)
       rescue ::Jarvis::UserProfileError => e
-        request.reply(t("user profile error", :user => request.user.mention_name, :class => e.class, :message => e.message))
+        request.reply_with_mention(t("user profile error", :class => e.class, :message => e.message))
       rescue => e
         # TODO(sissel): Mark this job as failed
-        request.reply(t("unhandled exception", :class => e.class, :message => e.message))
-        request.reply(e.backtrace.join("\n"))
+        request.reply_with_mention(t("unhandled exception", :class => e.class, :message => e.message))
+        request.reply_with_mention(e.backtrace.join("\n"))
       end
       # TODO(sissel): Mark this job as complete. (Once we have job/command tracking)
     end
   rescue Concurrent::RejectedExecutionError => e
-    request.reply(t("rejected execution", :pool => pool_name))
+    request.reply_with_mention(t("rejected execution", :pool => pool_name))
   rescue => e
-    request.reply(t("unhandled exception", :class => e.class, :message => e.message))
+    request.reply_with_mention(t("unhandled exception", :class => e.class, :message => e.message))
   end
 end end end

--- a/lib/lita-jarvis.rb
+++ b/lib/lita-jarvis.rb
@@ -5,6 +5,7 @@ Lita.load_locales Dir[File.expand_path(
 )]
 
 require "lita/handlers/jarvis"
+require "lita/handlers/heartbeat"
 
 Lita::Handlers::Jarvis.template_root File.expand_path(
   File.join("..", "..", "templates"),

--- a/lib/lita-jarvis.rb
+++ b/lib/lita-jarvis.rb
@@ -1,11 +1,13 @@
 require "lita"
 
+Thread.abort_on_exception = true
 Lita.load_locales Dir[File.expand_path(
   File.join("..", "..", "locales", "*.yml"), __FILE__
 )]
 
 require "lita/handlers/jarvis"
 require "lita/handlers/heartbeat"
+require "lita/handlers/settings"
 
 Lita::Handlers::Jarvis.template_root File.expand_path(
   File.join("..", "..", "templates"),

--- a/lib/lita/handlers/heartbeat.rb
+++ b/lib/lita/handlers/heartbeat.rb
@@ -6,88 +6,9 @@ require "time"
 
 module Lita
   module Handlers
-
-    # This handler exists because sometimes Hipchat's connection will simply
-    # die or go stale and the bot will never notice.
-    #
-    # The goal is to have the bot periodically ping itself through chat and
-    # restart if chat appears dead.
     class Heartbeat < Handler
-
-      # This key unique to each run of Lita/Jarvis.
-      HEARTBEAT_KEY = SecureRandom.uuid
-      HEARTBEAT_INTERVAL = 60 # seconds
-      HEARTBEAT_TIMEOUT = 180 # seconds
-
-      # Initial assumed "last heartbeat time" is start time of the program
-      LastHeartBeat = ::Concurrent::AtomicReference.new(Time.now.utc)
-
-      route(/^heartbeat (\S+) (\d+(?:\.\d+)?)/, :heartbeat, command: true)
-      route(/^ping\s*$/, :ping, :command => true)
-
-      #on(:loaded) do |*args|
-        ##if robot.config.adapter.any?
-        #if robot.config.adapters.respond_to?(:hipchat)
-          #puts "Starting chat health checker"
-          #Thread.new { self.class.heartbeat_loop(robot) }
-          #Thread.new { self.class.health_check_loop(robot) }
-        #else
-          #puts "No Lita adapter is configured. Chat health checker is disabled! This is OK only if the adapter is Shell. The rest of the time (production?) you will want this"
-        #end
-      #end
-
-      def self.heartbeat_loop(robot)
-        # Periodically send a heartbeat via chat to ourselves to verify that the actual chat system is alive.
-        Stud.interval(HEARTBEAT_INTERVAL) { send_heartbeat(robot) }
-      rescue => e
-        puts "Heartbeat loop died: #{e.class}: #{e}"
-      end
-
-      def self.send_heartbeat(robot)
-        robot.send_message(robot.name, "heartbeat #{HEARTBEAT_KEY} #{Time.now.to_f}")
-      end
-
-      def self.health_check_loop(robot)
-        Stud.interval(HEARTBEAT_TIMEOUT) { health_check(robot) }
-      rescue Exception => e
-        puts "Health check loop died: #{e}"
-      end
-
-      def self.health_check(robot)
-        last = LastHeartBeat.get
-        age = Time.now - last
-        if age > HEARTBEAT_TIMEOUT
-          puts "Last heartbeat was #{age} seconds ago; expiration time is #{HEARTBEAT_TIMEOUT}. Aborting..."
-
-          # Restart
-          exec($0)
-        end
-      rescue Exception => e
-        puts "Health check loop died: #{e.class}: #{e}"
-      end
-
-      def heartbeat(response)
-        key = response.match_data[1]
-        time = Time.at(response.match_data[2])
-        now = Time.now
-
-        if key != HEARTBEAT_KEY
-          response.reply("Invalid heartbeat key")
-          return
-        end
-
-        # Make sure the heartbeat isn't too old
-        age = now - time
-        if age > HEARTBEAT_TIMEOUT
-          puts "Received old heartbeat (#{age} seconds). Ignoring"
-          return
-        end
-
-        LastHeartBeat.set(now.utc)
-      end
-
-      def ping(response)
-        response.reply(I18n.t("lita.handlers.jarvis.ping response", :last_heartbeat => LastHeartBeat.get.iso8601))
+      route(/^ping\s*$/, :command => true) do |response|
+        response.reply(t("ping response"))
       end
 
       Lita.register_handler(self)

--- a/lib/lita/handlers/heartbeat.rb
+++ b/lib/lita/handlers/heartbeat.rb
@@ -25,16 +25,16 @@ module Lita
       route(/^heartbeat (\S+) (\d+(?:\.\d+)?)/, :heartbeat, command: true)
       route(/^ping\s*$/, :ping, :command => true)
 
-      on(:loaded) do |*args|
-        #if robot.config.adapter.any?
-        if robot.config.adapters.respond_to?(:hipchat)
-          puts "Starting chat health checker"
-          Thread.new { self.class.heartbeat_loop(robot) }
-          Thread.new { self.class.health_check_loop(robot) }
-        else
-          puts "No Lita adapter is configured. Chat health checker is disabled! This is OK only if the adapter is Shell. The rest of the time (production?) you will want this"
-        end
-      end
+      #on(:loaded) do |*args|
+        ##if robot.config.adapter.any?
+        #if robot.config.adapters.respond_to?(:hipchat)
+          #puts "Starting chat health checker"
+          #Thread.new { self.class.heartbeat_loop(robot) }
+          #Thread.new { self.class.health_check_loop(robot) }
+        #else
+          #puts "No Lita adapter is configured. Chat health checker is disabled! This is OK only if the adapter is Shell. The rest of the time (production?) you will want this"
+        #end
+      #end
 
       def self.heartbeat_loop(robot)
         # Periodically send a heartbeat via chat to ourselves to verify that the actual chat system is alive.

--- a/lib/lita/handlers/heartbeat.rb
+++ b/lib/lita/handlers/heartbeat.rb
@@ -26,7 +26,8 @@ module Lita
       route(/^ping\s*$/, :ping, :command => true)
 
       on(:loaded) do |*args|
-        if robot.config.adapter.any?
+        #if robot.config.adapter.any?
+        if robot.config.adapters.respond_to?(:hipchat)
           puts "Starting chat health checker"
           Thread.new { self.class.heartbeat_loop(robot) }
           Thread.new { self.class.health_check_loop(robot) }

--- a/lib/lita/handlers/heartbeat.rb
+++ b/lib/lita/handlers/heartbeat.rb
@@ -1,0 +1,95 @@
+require "securerandom"
+require "jarvis/commands/ping"
+require "concurrent"
+require "stud/interval"
+require "time"
+
+module Lita
+  module Handlers
+
+    # This handler exists because sometimes Hipchat's connection will simply
+    # die or go stale and the bot will never notice.
+    #
+    # The goal is to have the bot periodically ping itself through chat and
+    # restart if chat appears dead.
+    class Heartbeat < Handler
+
+      # This key unique to each run of Lita/Jarvis.
+      HEARTBEAT_KEY = SecureRandom.uuid
+      HEARTBEAT_INTERVAL = 60 # seconds
+      HEARTBEAT_TIMEOUT = 180 # seconds
+
+      # Initial assumed "last heartbeat time" is start time of the program
+      LastHeartBeat = ::Concurrent::AtomicReference.new(Time.now.utc)
+
+      route(/^heartbeat (\S+) (\d+(?:\.\d+)?)/, :heartbeat, command: true)
+      route(/^ping\s*$/, :ping, :command => true)
+
+      on(:loaded) do |*args|
+        if robot.config.adapter.any?
+          puts "Starting chat health checker"
+          Thread.new { self.class.heartbeat_loop(robot) }
+          Thread.new { self.class.health_check_loop(robot) }
+        else
+          puts "No Lita adapter is configured. Chat health checker is disabled! This is OK only if the adapter is Shell. The rest of the time (production?) you will want this"
+        end
+      end
+
+      def self.heartbeat_loop(robot)
+        # Periodically send a heartbeat via chat to ourselves to verify that the actual chat system is alive.
+        Stud.interval(HEARTBEAT_INTERVAL) { send_heartbeat(robot) }
+      rescue => e
+        puts "Heartbeat loop died: #{e.class}: #{e}"
+      end
+
+      def self.send_heartbeat(robot)
+        robot.send_message(robot.name, "heartbeat #{HEARTBEAT_KEY} #{Time.now.to_f}")
+      end
+
+      def self.health_check_loop(robot)
+        Stud.interval(HEARTBEAT_TIMEOUT) { health_check(robot) }
+      rescue Exception => e
+        puts "Health check loop died: #{e}"
+      end
+
+      def self.health_check(robot)
+        last = LastHeartBeat.get
+        age = Time.now - last
+        if age > HEARTBEAT_TIMEOUT
+          puts "Last heartbeat was #{age} seconds ago; expiration time is #{HEARTBEAT_TIMEOUT}. Aborting..."
+
+          # Restart
+          exec($0)
+        end
+      rescue Exception => e
+        puts "Health check loop died: #{e.class}: #{e}"
+      end
+
+      def heartbeat(response)
+        key = response.match_data[1]
+        time = Time.at(response.match_data[2])
+        now = Time.now
+
+        if key != HEARTBEAT_KEY
+          response.reply("Invalid heartbeat key")
+          return
+        end
+
+        # Make sure the heartbeat isn't too old
+        age = now - time
+        if age > HEARTBEAT_TIMEOUT
+          puts "Received old heartbeat (#{age} seconds). Ignoring"
+          return
+        end
+
+        LastHeartBeat.set(now.utc)
+      end
+
+      def ping(response)
+        response.reply(I18n.t("lita.handlers.jarvis.ping response", :last_heartbeat => LastHeartBeat.get.iso8601))
+      end
+
+      Lita.register_handler(self)
+    end
+  end
+end

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -7,13 +7,17 @@ module Lita
   module Handlers
     class Jarvis < Handler
       extend ::Jarvis::Mixins::FancyRoute
+      config :cla_url
+      config :organization
 
       fancy_route("restart", ::Jarvis::Command::Bounce, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
       fancy_route("merge", ::Jarvis::Command::Merge, :command => true, :flags => {
         "--committer-email" => ->(request) { request.user.metadata["git-email"] || raise(::Jarvis::UserProfileError, "Missing user setting `git-email` for user #{request.user.name}") },
         "--committer-name" => ->(request) { request.user.name },
       })
-      fancy_route("cla", ::Jarvis::Command::CLA, :command => true)
+      fancy_route("cla", ::Jarvis::Command::CLA, :command => true, :flags => {
+        "--cla-url" => ->(_) { config.find { |c| c.name == :cla_url }.value },
+      })
 
       Lita.register_handler(self)
     end

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -10,7 +10,8 @@ module Lita
 
       fancy_route("restart", ::Jarvis::Command::Bounce, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
       fancy_route("merge", ::Jarvis::Command::Merge, :command => true, :flags => {
-        "--committer" => ->(request) { request.user.metadata["git-email"] || raise(::Jarvis::UserProfileError, "Missing user setting `git-email` for user #{request.user.name}") }
+        "--committer-email" => ->(request) { request.user.metadata["git-email"] || raise(::Jarvis::UserProfileError, "Missing user setting `git-email` for user #{request.user.name}") },
+        "--committer-name" => ->(request) { request.user.name },
       })
       fancy_route("cla", ::Jarvis::Command::CLA, :command => true)
 

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -16,7 +16,7 @@ module Lita
         "--committer-name" => ->(request) { request.user.name },
       })
       fancy_route("cla", ::Jarvis::Command::CLA, :command => true, :flags => {
-        "--cla-url" => ->(_) { config.find { |c| c.name == :cla_url }.value },
+        "--cla-url" => ->(_) { config.find { |c| c.name == :cla_url }.value || raise(::Jarvis::Error, "Missing this setting in lita_config.rb: config.handlers.jarvis.cla_url") }
       })
 
       Lita.register_handler(self)

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -1,6 +1,7 @@
 require "jarvis/commands/merge"
 require "jarvis/commands/bounce"
 require "jarvis/commands/cla"
+require "jarvis/commands/ping"
 require "jarvis/mixins/fancy_route"
 
 module Lita
@@ -10,6 +11,7 @@ module Lita
 
       fancy_route("merge", ::Jarvis::Command::Merge, :command => true)
       fancy_route("cla", ::Jarvis::Command::CLA, :command => true)
+      fancy_route("ping", ::Jarvis::Command::Ping, :command => true)
       fancy_route("bounce", ::Jarvis::Command::Bounce, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
 
       Lita.register_handler(self)

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -9,7 +9,9 @@ module Lita
       extend ::Jarvis::Mixins::FancyRoute
 
       fancy_route("restart", ::Jarvis::Command::Bounce, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
-      fancy_route("merge", ::Jarvis::Command::Merge, :command => true)
+      fancy_route("merge", ::Jarvis::Command::Merge, :command => true, :flags => {
+        "--committer" => ->(request) { request.user.metadata["git-email"] || raise(::Jarvis::UserProfileError, "Missing user setting `git-email` for user #{request.user.name}") }
+      })
       fancy_route("cla", ::Jarvis::Command::CLA, :command => true)
 
       Lita.register_handler(self)

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -8,15 +8,17 @@ module Lita
     class Jarvis < Handler
       extend ::Jarvis::Mixins::FancyRoute
       config :cla_url
+      config :github_token
       config :organization
 
       fancy_route("restart", ::Jarvis::Command::Bounce, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
       fancy_route("merge", ::Jarvis::Command::Merge, :command => true, :flags => {
         "--committer-email" => ->(request) { request.user.metadata["git-email"] || raise(::Jarvis::UserProfileError, "Missing user setting `git-email` for user #{request.user.name}") },
         "--committer-name" => ->(request) { request.user.name },
+        "--github-token" => ->(_) { config.find { |c| c.name == :github_token }.value || raise(::Jarvis::Error, "Missing this setting in lita_config.rb: config.handlers.jarvis.github_token") }
       })
       fancy_route("cla", ::Jarvis::Command::CLA, :command => true, :flags => {
-        "--cla-url" => ->(_) { config.find { |c| c.name == :cla_url }.value || raise(::Jarvis::Error, "Missing this setting in lita_config.rb: config.handlers.jarvis.cla_url") }
+        "--cla-url" => ->(_) { config.find { |c| c.name == :cla_url }.value || raise(::Jarvis::Error, "Missing this setting in lita_config.rb: config.handlers.jarvis.cla_url") },
       })
 
       Lita.register_handler(self)

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -1,7 +1,6 @@
 require "jarvis/commands/merge"
 require "jarvis/commands/bounce"
 require "jarvis/commands/cla"
-require "jarvis/commands/ping"
 require "jarvis/mixins/fancy_route"
 
 module Lita
@@ -9,10 +8,15 @@ module Lita
     class Jarvis < Handler
       extend ::Jarvis::Mixins::FancyRoute
 
+      on(:loaded) do |*args|
+        #p :connection => args
+        #require "pry"
+        #binding.pry
+      end
+
+      fancy_route("restart", ::Jarvis::Command::Bounce, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
       fancy_route("merge", ::Jarvis::Command::Merge, :command => true)
       fancy_route("cla", ::Jarvis::Command::CLA, :command => true)
-      fancy_route("ping", ::Jarvis::Command::Ping, :command => true)
-      fancy_route("bounce", ::Jarvis::Command::Bounce, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
 
       Lita.register_handler(self)
     end

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -8,12 +8,6 @@ module Lita
     class Jarvis < Handler
       extend ::Jarvis::Mixins::FancyRoute
 
-      on(:loaded) do |*args|
-        #p :connection => args
-        #require "pry"
-        #binding.pry
-      end
-
       fancy_route("restart", ::Jarvis::Command::Bounce, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
       fancy_route("merge", ::Jarvis::Command::Merge, :command => true)
       fancy_route("cla", ::Jarvis::Command::CLA, :command => true)

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -1,5 +1,6 @@
 require "jarvis/commands/merge"
 require "jarvis/commands/bounce"
+require "jarvis/commands/cla"
 require "jarvis/mixins/fancy_route"
 
 module Lita
@@ -8,6 +9,7 @@ module Lita
       extend ::Jarvis::Mixins::FancyRoute
 
       fancy_route("merge", ::Jarvis::Command::Merge, :command => true)
+      fancy_route("cla", ::Jarvis::Command::CLA, :command => true)
       fancy_route("bounce", ::Jarvis::Command::Bounce, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
 
       Lita.register_handler(self)

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -1,6 +1,7 @@
 require "jarvis/commands/merge"
 require "jarvis/commands/bounce"
 require "jarvis/commands/cla"
+require "jarvis/commands/publish"
 require "jarvis/mixins/fancy_route"
 
 module Lita
@@ -19,6 +20,11 @@ module Lita
       })
       fancy_route("cla", ::Jarvis::Command::CLA, :command => true, :flags => {
         "--cla-url" => ->(_) { config.find { |c| c.name == :cla_url }.value || raise(::Jarvis::Error, "Missing this setting in lita_config.rb: config.handlers.jarvis.cla_url") },
+      })
+      fancy_route("publish", ::Jarvis::Command::Publish, :command => true, :flags => {
+        "--committer-email" => ->(request) { request.user.metadata["git-email"] || raise(::Jarvis::UserProfileError, "Missing user setting `git-email` for user #{request.user.name}") },
+        "--committer-name" => ->(request) { request.user.name },
+        "--github-token" => ->(_) { config.find { |c| c.name == :github_token }.value || raise(::Jarvis::Error, "Missing this setting in lita_config.rb: config.handlers.jarvis.github_token") }
       })
 
       Lita.register_handler(self)

--- a/lib/lita/handlers/settings.rb
+++ b/lib/lita/handlers/settings.rb
@@ -4,7 +4,7 @@ module Lita module Handlers class Settings < Handler
     _, key, value, *_ = request.match_data.to_a
     request.user.metadata[key] = value
     request.user.save
-    request.reply(t("user profile updated", :user => request.user.name, :key => key))
+    request.reply(t("response.user profile updated", :user => request.user.mention_name, :key => key))
   end
 
   # user get some-key
@@ -12,9 +12,9 @@ module Lita module Handlers class Settings < Handler
     _, key, *_ = request.match_data.to_a
     value = request.user.metadata[key]
     if value
-      request.reply(t("response.user profile get", :user => request.user.name, :key => key, :value => value))
+      request.reply(t("response.user profile get", :user => request.user.mention_name, :key => key, :value => value))
     else
-      request.reply(t("response.user profile key not set", :user => request.user.name, :key => key))
+      request.reply(t("response.user profile key not set", :user => request.user.mention_name, :key => key))
     end
   end
  
@@ -23,7 +23,7 @@ module Lita module Handlers class Settings < Handler
     _, key, *_ = request.match_data.to_a
     request.user.metadata.delete(key)
     request.user.save
-    request.reply(t("response.user profile clear", :user => request.user.name, :key => key))
+    request.reply(t("response.user profile clear", :user => request.user.mention_name, :key => key))
   end
 
   route(/^user\s+get\s*$/, :command => true, :help => {"user get" => t("help.user get")}) do |request|

--- a/lib/lita/handlers/settings.rb
+++ b/lib/lita/handlers/settings.rb
@@ -1,20 +1,37 @@
 module Lita module Handlers class Settings < Handler
   # set user some-key some-value
-  route(/^set\s+user\s+(\S+)\s+(.*)\s*$/, :command => true, :help => {"set user <key> <value>" => t("set user")}) do |request|
+  route(/^user\s+get\s+(\S+)\s+(.*)\s*$/, :command => true, :help => {"user set <key> <value>" => t("help.user set")}) do |request|
     _, key, value, *_ = request.match_data.to_a
     request.user.metadata[key] = value
     request.user.save
     request.reply(t("user profile updated", :user => request.user.name, :key => key))
   end
 
-  # get user some-key
-  route(/^get\s+user\s+(\S+)\s*$/, :command => true, :help => {"get user <key>" => t("get user")}) do |request|
+  # user get some-key
+  route(/^user\s+get\s+(\S+)\s*$/, :command => true, :help => {"user get <key>" => t("help.user get")}) do |request|
     _, key, *_ = request.match_data.to_a
     value = request.user.metadata[key]
     if value
-      request.reply(t("user profile get", :user => request.user.name, :key => key, :value => value))
+      request.reply(t("response.user profile get", :user => request.user.name, :key => key, :value => value))
     else
-      request.reply(t("user profile key not set", :user => request.user.name, :key => key))
+      request.reply(t("response.user profile key not set", :user => request.user.name, :key => key))
+    end
+  end
+ 
+  # clear user some-key
+  route(/^user\s+clear\s+(\S+)\s*$/, :command => true, :help => {"user clear <key>" => t("help.user clear")}) do |request|
+    _, key, *_ = request.match_data.to_a
+    request.user.metadata.delete(key)
+    request.user.save
+    request.reply(t("response.user profile clear", :user => request.user.name, :key => key))
+  end
+
+  route(/^user\s+get\s*$/, :command => true, :help => {"user get" => t("help.user get")}) do |request|
+    text = request.user.metadata.collect { |k,v| "#{k} = #{v}" }.join("\n")
+    if text.empty?
+      request.reply(t("response.empty user profile"))
+    else
+      request.reply(text)
     end
   end
 

--- a/lib/lita/handlers/settings.rb
+++ b/lib/lita/handlers/settings.rb
@@ -1,0 +1,23 @@
+module Lita module Handlers class Settings < Handler
+  # set user some-key some-value
+  route(/^set\s+user\s+(\S+)\s+(.*)\s*$/, :command => true, :help => {"set user <key> <value>" => t("set user")}) do |request|
+    _, key, value, *_ = request.match_data.to_a
+    request.user.metadata[key] = value
+    request.user.save
+    request.reply(t("user profile updated", :user => request.user.name, :key => key))
+  end
+
+  # get user some-key
+  route(/^get\s+user\s+(\S+)\s*$/, :command => true, :help => {"get user <key>" => t("get user")}) do |request|
+    _, key, *_ = request.match_data.to_a
+    value = request.user.metadata[key]
+    if value
+      request.reply(t("user profile get", :user => request.user.name, :key => key, :value => value))
+    else
+      request.reply(t("user profile key not set", :user => request.user.name, :key => key))
+    end
+  end
+
+  Lita.register_handler(self)
+end end end
+

--- a/lib/lita/handlers/settings.rb
+++ b/lib/lita/handlers/settings.rb
@@ -4,7 +4,7 @@ module Lita module Handlers class Settings < Handler
     _, key, value, *_ = request.match_data.to_a
     request.user.metadata[key] = value
     request.user.save
-    request.reply(t("response.user profile updated", :user => request.user.mention_name, :key => key))
+    request.reply_with_mention(t("response.user profile updated", :key => key))
   end
 
   # user get some-key
@@ -12,9 +12,9 @@ module Lita module Handlers class Settings < Handler
     _, key, *_ = request.match_data.to_a
     value = request.user.metadata[key]
     if value
-      request.reply(t("response.user profile get", :user => request.user.mention_name, :key => key, :value => value))
+      request.reply_with_mention(t("response.user profile get", :key => key, :value => value))
     else
-      request.reply(t("response.user profile key not set", :user => request.user.mention_name, :key => key))
+      request.reply_with_mention(t("response.user profile key not set", :key => key))
     end
   end
  
@@ -23,15 +23,15 @@ module Lita module Handlers class Settings < Handler
     _, key, *_ = request.match_data.to_a
     request.user.metadata.delete(key)
     request.user.save
-    request.reply(t("response.user profile clear", :user => request.user.mention_name, :key => key))
+    request.reply_with_mention(t("response.user profile clear", :key => key))
   end
 
   route(/^user\s+get\s*$/, :command => true, :help => {"user get" => t("help.user get")}) do |request|
     text = request.user.metadata.collect { |k,v| "#{k} = #{v}" }.join("\n")
     if text.empty?
-      request.reply(t("response.empty user profile"))
+      request.reply_with_mention(t("response.empty user profile"))
     else
-      request.reply(text)
+      request.reply_with_mention(text)
     end
   end
 

--- a/lib/lita/handlers/settings.rb
+++ b/lib/lita/handlers/settings.rb
@@ -1,6 +1,6 @@
 module Lita module Handlers class Settings < Handler
   # set user some-key some-value
-  route(/^user\s+get\s+(\S+)\s+(.*)\s*$/, :command => true, :help => {"user set <key> <value>" => t("help.user set")}) do |request|
+  route(/^user\s+set\s+(\S+)\s+(.*)\s*$/, :command => true, :help => {"user set <key> <value>" => t("help.user set")}) do |request|
     _, key, value, *_ = request.match_data.to_a
     request.user.metadata[key] = value
     request.user.save

--- a/lita-jarvis.gemspec
+++ b/lita-jarvis.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "pry-byebug"
+  spec.add_development_dependency "flores"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rspec", ">= 3.0.0"

--- a/lita-jarvis.gemspec
+++ b/lita-jarvis.gemspec
@@ -3,10 +3,10 @@ Gem::Specification.new do |spec|
   spec.version       = "0.1.0"
   spec.authors       = ["Jordan Sissel"]
   spec.email         = ["jls@semicomplete.com"]
-  spec.description   = "TODO: Add a description"
-  spec.summary       = "TODO: Add a summary"
-  spec.homepage      = "TODO: Add a homepage"
-  spec.license       = "TODO: Add a license"
+  spec.description   = "-"
+  spec.summary       = "A chatops bot used at Elastic"
+  spec.homepage      = "https://github.com/elastic/jarvis"
+  spec.license       = "Apache Licence version 2.0"
   spec.metadata      = { "lita_plugin_type" => "handler" }
 
   spec.files         = `git ls-files`.split($/)
@@ -16,9 +16,11 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "lita", ">= 4.6"
   spec.add_runtime_dependency "clamp", "~> 1.0.0"
+  spec.add_runtime_dependency "stud"
+  spec.add_runtime_dependency "concurrent-ruby", "0.9.1"
+  spec.add_runtime_dependency "git", "~> 1.2.9"
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "concurrent-ruby"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"

--- a/lita-jarvis.gemspec
+++ b/lita-jarvis.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "lita", ">= 4.6"
   spec.add_runtime_dependency "clamp", "~> 1.0.0"
+  spec.add_runtime_dependency "mustache"
+  spec.add_runtime_dependency "octokit"
   spec.add_runtime_dependency "stud"
   spec.add_runtime_dependency "concurrent-ruby", "0.9.1"
   spec.add_runtime_dependency "git", "~> 1.2.9"
@@ -23,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "mbox"
   spec.add_runtime_dependency "cabin"
   spec.add_runtime_dependency "open4"
-  spec.add_runtime_dependency "lita-hipchat"
+  #spec.add_runtime_dependency "lita-hipchat"
   spec.add_runtime_dependency "faraday_middleware"
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lita-jarvis.gemspec
+++ b/lita-jarvis.gemspec
@@ -19,6 +19,12 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "stud"
   spec.add_runtime_dependency "concurrent-ruby", "0.9.1"
   spec.add_runtime_dependency "git", "~> 1.2.9"
+  spec.add_runtime_dependency "faraday"
+  spec.add_runtime_dependency "mbox"
+  spec.add_runtime_dependency "cabin"
+  spec.add_runtime_dependency "open4"
+  spec.add_runtime_dependency "lita-hipchat"
+  spec.add_runtime_dependency "faraday_middleware"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "pry-byebug"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -32,7 +32,7 @@ en:
         rejected execution: >-
           The %{pool} pool is full, so I am too busy to do that work right now, sorry! (shrug)
         ping response: >-
-          (chompy) Last heartbeat: %{last_heartbeat}
+          (chompy) (new jarvis)
         user profile error: >-
           %{user}: (whoa) %{class}: %{message}.
           You can resolve this by telling me your git email `set git-email

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -19,6 +19,8 @@ en:
       jarvis:
         merge success: |-
           (success) Merged %{organization}/%{project}#%{number} into %{branches}
+        publish success: |-
+          (success) Published %{organization}/%{project} from the following branches: %{branches}
         exception: |-
           (sadpanda) An error occurred in %{command}: %{exception} - %{message}
           %{stacktrace}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,14 +2,20 @@ en:
   lita:
     handlers:
       settings:
-        set user: Set a value for your chat profile.
-        get user: Get the current value for a given setting in your chat profile.
-        user profile updated: >-
-          %{user}: Ok! Updated `%{key}` for your profile.
-        user profile get: >-
-          %{user}: %{key} = %{value}
-        user profile key not set: >-
-          %{user}: %{key} has no value for your profile.
+        help:
+          user set: Set a value for your chat profile.
+          user get: Get the current value for a given setting in your chat profile.
+          user clear: Remove a given setting.
+        response:
+          empty user profile: Your profile has no settings.
+          user profile updated: >-
+            %{user}: Ok! Updated `%{key}` for your profile.
+          user profile get: >-
+            %{user}: %{key} = %{value}
+          user profile clear: >-
+            %{user}: %{key} cleared.
+          user profile key not set: >-
+            %{user}: %{key} has no value for your profile.
       jarvis:
         merge success: |-
           (success) Merged %{organization}/%{project}#%{number} into %{branches}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -34,7 +34,7 @@ en:
         ping response: >-
           (chompy) (new jarvis)
         user profile error: >-
-          @%{user}: (whoa) %{class}: %{message}.
+          (whoa) %{class}: %{message}.
           You can resolve this by telling me your git email `set git-email
           your@email-address`. I need this information for setting the git
           committer data during the merge.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -10,7 +10,7 @@ en:
         rejected execution: >-
           The %{pool} pool is full, so I am too busy to do that work right now, sorry! (shrug)
         ping response: >-
-          (chompy)
+          (chompy) Last heartbeat: %{last_heartbeat}
         cla:
           failure: |-
             (failed) %{project}#%{pr} - %{message}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,6 +2,9 @@ en:
   lita:
     handlers:
       jarvis:
+        exception: >-
+          (sadpanda) An error occurred in %{command}: %{exception} - %{message}
+          %{stacktrace}
         unhandled exception: >-
           (boom) Unhandled exception: %{exception}
         rejected execution: >-

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -7,3 +7,10 @@ en:
         rejected execution: >-
           The %{pool} pool is full, so I am too busy to do that work right now,
           sorry!
+        cla:
+          failure: |-
+            (failed) %{project}#%{pr} - %{message}
+          success: |-
+            (freddie) %{project}#%{pr} - %{message}
+
+

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -11,9 +11,14 @@ en:
         user profile key not set: >-
           %{user}: %{key} has no value for your profile.
       jarvis:
-        exception: >-
+        merge success: |-
+          (success) Merged %{organization}/%{project}#{number} into %{branches}
+        exception: |-
           (sadpanda) An error occurred in %{command}: %{exception} - %{message}
           %{stacktrace}
+
+          Logs from this execution:
+          %{logs}
         unhandled exception: >-
           (boom) Unhandled exception: %{class} - %{message}
         rejected execution: >-

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -16,6 +16,9 @@ en:
             %{key} cleared.
           user profile key not set: >-
             %{key} has no value for your profile.
+      heartbeat:
+        ping response: >-
+          (chompy) (new jarvis)
       jarvis:
         merge success: |-
           (success) Merged %{organization}/%{project}#%{number} into %{branches}
@@ -31,8 +34,6 @@ en:
           (boom) Unhandled exception: %{class} - %{message}
         rejected execution: >-
           The %{pool} pool is full, so I am too busy to do that work right now, sorry! (shrug)
-        ping response: >-
-          (chompy) (new jarvis)
         user profile error: >-
           (whoa) %{class}: %{message}.
           You can resolve this by telling me your git email `set git-email

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,14 +3,14 @@ en:
     handlers:
       jarvis:
         unhandled exception: >-
-          Unhandled exception: %{exception}
+          (boom) Unhandled exception: %{exception}
         rejected execution: >-
-          The %{pool} pool is full, so I am too busy to do that work right now,
-          sorry!
+          The %{pool} pool is full, so I am too busy to do that work right now, sorry! (shrug)
+        ping response: >-
+          (chompy)
         cla:
           failure: |-
             (failed) %{project}#%{pr} - %{message}
           success: |-
             (freddie) %{project}#%{pr} - %{message}
-
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,16 +1,30 @@
 en:
   lita:
     handlers:
+      settings:
+        set user: Set a value for your chat profile.
+        get user: Get the current value for a given setting in your chat profile.
+        user profile updated: >-
+          %{user}: Ok! Updated `%{key}` for your profile.
+        user profile get: >-
+          %{user}: %{key} = %{value}
+        user profile key not set: >-
+          %{user}: %{key} has no value for your profile.
       jarvis:
         exception: >-
           (sadpanda) An error occurred in %{command}: %{exception} - %{message}
           %{stacktrace}
         unhandled exception: >-
-          (boom) Unhandled exception: %{exception}
+          (boom) Unhandled exception: %{class} - %{message}
         rejected execution: >-
           The %{pool} pool is full, so I am too busy to do that work right now, sorry! (shrug)
         ping response: >-
           (chompy) Last heartbeat: %{last_heartbeat}
+        user profile error: >-
+          %{user}: (whoa) %{class}: %{message}.
+          You can resolve this by telling me your git email `set git-email
+          your@email-address`. I need this information for setting the git
+          committer data during the merge.
         cla:
           failure: |-
             (failed) %{project}#%{pr} - %{message}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -12,7 +12,7 @@ en:
           %{user}: %{key} has no value for your profile.
       jarvis:
         merge success: |-
-          (success) Merged %{organization}/%{project}#{number} into %{branches}
+          (success) Merged %{organization}/%{project}#%{number} into %{branches}
         exception: |-
           (sadpanda) An error occurred in %{command}: %{exception} - %{message}
           %{stacktrace}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -9,13 +9,13 @@ en:
         response:
           empty user profile: Your profile has no settings.
           user profile updated: >-
-            %{user}: Ok! Updated `%{key}` for your profile.
+            Ok! Updated `%{key}` for your profile.
           user profile get: >-
-            %{user}: %{key} = %{value}
+            %{key} = %{value}
           user profile clear: >-
-            %{user}: %{key} cleared.
+            %{key} cleared.
           user profile key not set: >-
-            %{user}: %{key} has no value for your profile.
+            %{key} has no value for your profile.
       jarvis:
         merge success: |-
           (success) Merged %{organization}/%{project}#%{number} into %{branches}
@@ -34,7 +34,7 @@ en:
         ping response: >-
           (chompy) (new jarvis)
         user profile error: >-
-          %{user}: (whoa) %{class}: %{message}.
+          @%{user}: (whoa) %{class}: %{message}.
           You can resolve this by telling me your git email `set git-email
           your@email-address`. I need this information for setting the git
           committer data during the merge.

--- a/spec/jarvis/cla_spec.rb
+++ b/spec/jarvis/cla_spec.rb
@@ -1,0 +1,63 @@
+require "jarvis/cla"
+require "flores/random"
+
+# because URI.escape is broken and doesn't escape @ or other characters...
+require "cgi" 
+
+describe Jarvis::CLA do
+
+  let(:user) { CGI.escape(Flores::Random.text(10)) }
+  let(:password) { CGI.escape(Flores::Random.text(10)) }
+  let(:host) { "example.com" }
+  let(:path) { "/example" }
+
+  let(:cla_uri) { 
+    URI::Generic.build(scheme: "https",
+                       userinfo: [user, password].join(":"),
+                       host: host,
+                       path: path)
+  }
+
+  let(:response) do
+     double("faraday response")
+  end
+
+  let(:connection) do
+    double("Faraday::Connection")
+  end
+
+  before do
+    allow(response).to receive(:body).and_return(json_response)
+    allow(connection).to receive(:basic_auth).with(user, password)
+    allow(connection).to receive(:get).with(cla_uri.path, kind_of(Hash)).and_return(response)
+    allow(Faraday).to receive(:new).and_return(connection)
+  end
+
+  shared_examples_for "a cla check" do |bool, status, message|
+    let(:message) { message }
+    let(:json_response) {
+      JSON.dump("status" => status, "message" => message)
+    }
+
+    subject { Jarvis::CLA.check(cla_uri.to_s, "example/repo", 1234) }
+
+    describe "#ok?" do
+      it "should return #{bool}" do
+        expect(subject.ok?).to eq(bool)
+      end
+    end
+
+    describe "message" do
+      it "should return the message given by the CLA api call" do
+        expect(subject.message).to eq(message)
+      end
+    end
+  end
+
+  context "when a CLA check fails" do
+    it_behaves_like "a cla check", false, "failure", "some failure message"
+  end
+  context "when a CLA check succeeds" do
+    it_behaves_like "a cla check", true, "success", "some success message"
+  end
+end

--- a/spec/jarvis/clamp_delegate_spec.rb
+++ b/spec/jarvis/clamp_delegate_spec.rb
@@ -55,6 +55,7 @@ describe Jarvis::ClampDelegate do
           def execute; end
         end
       end
+
       let(:delegate) { described_class.delegate(clamp, flags: flags) }
       let(:command_line_text) { "" }
 
@@ -67,6 +68,7 @@ describe Jarvis::ClampDelegate do
           delegate.call(request)
         end
       end
+
       context "with a valid flag" do
         let(:flags) do
           { "--name" => ->(_) { "Jordan" } }

--- a/spec/jarvis/github/project_spec.rb
+++ b/spec/jarvis/github/project_spec.rb
@@ -1,0 +1,41 @@
+require "jarvis/github/project"
+
+describe Jarvis::GitHub::Project do
+  describe "#parse" do
+    context "with a valid url" do
+      let(:urls) do
+        [ 
+          "https://github.com/foo/bar",
+          "https://github.com/foo/bar/123",
+          "https://github.com/foo/bar/issues/123",
+          "https://github.com/foo/bar/issue/123",
+          "https://github.com/foo/bar/pull/abcd",
+        ]
+      end
+
+      it "succeeds" do
+        urls.each do |url|
+          expect { described_class.parse(url) }.not_to raise_error
+          project = described_class.parse(url)
+          expect(project.organization).to be == "foo"
+          expect(project.name).to be == "bar"
+        end
+      end
+    end
+
+    context "with an invalid url" do
+      let(:urls) do
+        [
+          "https",
+          "https://github.com",
+        ]
+      end
+
+      it "fails" do
+        urls.each do |url|
+          expect { described_class.parse(url) }.to raise_error(Jarvis::GitHub::Project::InvalidURL)
+        end
+      end
+    end
+  end
+end

--- a/spec/jarvis/github/pull_request_spec.rb
+++ b/spec/jarvis/github/pull_request_spec.rb
@@ -1,0 +1,37 @@
+require "jarvis/github/pull_request"
+
+describe Jarvis::GitHub::PullRequest do
+  describe "#parse" do
+    context "with a valid url" do
+      let(:url) { "https://github.com/foo/bar/pull/123" }
+
+      it "succeeds" do
+        expect { described_class.parse(url) }.not_to raise_error
+        pr = described_class.parse(url)
+        expect(pr.organization).to be == "foo"
+        expect(pr.project).to be == "bar"
+        expect(pr.number).to be == "123"
+      end
+    end
+
+    context "with an invalid url" do
+      let(:urls) do
+        [
+          "https",
+          "https://github.com",
+          "https://github.com/foo/bar",
+          "https://github.com/foo/bar/123",
+          "https://github.com/foo/bar/issues/123",
+          "https://github.com/foo/bar/issue/123",
+          "https://github.com/foo/bar/pull/abcd",
+        ]
+      end
+
+      it "fails" do
+        urls.each do |url|
+          expect { described_class.parse(url) }.to raise_error(Jarvis::GitHub::PullRequest::InvalidURL)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,2 @@
 require "lita-jarvis"
 require "lita/rspec"
-
-# A compatibility mode is provided for older plugins upgrading from Lita 3. Since this plugin
-# was generated with Lita 4, the compatibility mode should be left disabled.
-Lita.version_3_compatibility_mode = false

--- a/templates/github_merge_comment.mustache
+++ b/templates/github_merge_comment.mustache
@@ -1,6 +1,4 @@
-I've merged this into the following branches!
-
-Merged by {{ committer }}
+{{ committer }} merged this into the following branches!
 
 Branch | Commits
 -------|--------

--- a/templates/github_merge_comment.mustache
+++ b/templates/github_merge_comment.mustache
@@ -1,0 +1,9 @@
+I've merged this into the following branches!
+
+Merged by {{ committer }}
+
+Branch | Commits
+-------|--------
+{{#commits}}
+{{branch}} | {{commits}}
+{{/commits}}


### PR DESCRIPTION
This is another large-sweep as part of the refactor/rewrite of Jarvis.

Major changes:

* Clamp delegation now supports passing flag values that come from the request or Lita's environment (see the 'merge' command fancy_route example)
* Implemented merge and cla commands.
* Added user profile settings via `user set [key] [value]` and `user set [key]`. This is used for telling Lita what your git name+email are for the purposes of merging. (Fixes #16)
* Much more logging is captured during merge execution and is published only on error. At this time, I think _all_ output from the merge command, on failure, will reach the user (instead of the console output!) for easier debugging.
* Verified 'restart' command works.
* Implemented ping command which also shows last-successful heartbeat time.
* I tried to implement heartbeat but Lita will ignore its own messages :(
* Added merge and publish commands.