### PR TITLE
Make sure we output the log at the end of an exception run to give some feedback to the user.

### DIFF
--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -121,6 +121,7 @@ module Jarvis module Command class Publish < Clamp::Command
                   :project => project.name,
                   :branch => branch)
     end
+    puts logs.join("\n")
   rescue => e
     puts I18n.t("lita.handlers.jarvis.exception", :exception => e.class,
                 :message => e.to_s,


### PR DESCRIPTION
Currently went something bad happen when trying to publish a plugin no feedback is giving to the user, the task just dies silently. This PR make sure we output the content of the log to user all the time.

This is a first step to refactor the retroaction given to the user.