### PR TITLE
Always run rake vendor

### DIFF
--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -28,7 +28,7 @@ module Jarvis module Command class Publish < Clamp::Command
   ALWAYS_RUN = lambda { |workdir| true }
 
   TASKS = { "bundle install" => ALWAYS_RUN,
-            "bundle exec rake vendor" => lambda { |directory| Dir.glob(File.join(directory, "**/vendor.json")).size > 0 },
+            "bundle exec rake vendor" => ALWAYS_RUN,
             "bundle exec rake publish_gem" => ALWAYS_RUN }.freeze
 
   NO_PREVIOUS_GEMS_PUBLISHED = "This rubygem could not be found."


### PR DESCRIPTION
This PR changes the behavior of jarvis to always run the `rake vendor`
on every plugin to make sure that java plugins bundle their jars.