### PR TITLE
Search whole elastic repo + fix total calculation

### DIFF
--- a/lib/jarvis/github/review_search.rb
+++ b/lib/jarvis/github/review_search.rb
@@ -3,13 +3,13 @@ module Jarvis; module Github; module ReviewSearch
     search_base = "assignee:\"elasticsearch-bot\" state:open"
     
     searches = [
-      search_base + " org:logstash-plugins",
-      search_base + " repo:elastic/logstash"
-    ]
+      "org:logstash-plugins",
+      "org:elastic"
+    ].map {|scope| search_base + " " + scope}
 
     results = searches.map {|q| ::Jarvis::Github.client.search_issues(q) }
 
-    total = results.reduce {|r| r[:total_count] }
+    total = results.reduce(0) {|acc,r| acc + r[:total_count] }
     items = results.flat_map {|r| r[:items]}
 
     [total, items]


### PR DESCRIPTION
This also fixes the calculation of the total open reviews, which
previously was just the result of a single search