### PR TITLE
Ensure UTF-8 encoding is used independent of environment.

### DIFF
--- a/lib/jarvis/commands/merge.rb
+++ b/lib/jarvis/commands/merge.rb
@@ -9,12 +9,16 @@ require "stud/temporary"
 require "jarvis/github/pull_request"
 require "jarvis/patches/i18n"
 require "jarvis/git"
+require "jarvis/github"
 require "jarvis/fetch"
 require "jarvis/defer"
 require "mbox"
 
 module Jarvis module Command class Merge < Clamp::Command
   include ::Jarvis::Github
+
+  Encoding.default_external = Encoding::UTF_8
+  Encoding.default_internal = Encoding::UTF_8
 
   class PushFailure < ::Jarvis::Error; end
   class Bug < ::Jarvis::Error; end

--- a/lib/jarvis/fetch.rb
+++ b/lib/jarvis/fetch.rb
@@ -20,7 +20,7 @@ module Jarvis module Fetch
       raise DownloadFailure, "Got HTTP #{response.status} when fetching #{url}"
     end
 
-    file.write(response.body)
+    file.write(response.body.force_encoding('utf-8'))
     file.flush
     file.rewind
 

--- a/lita-jarvis.gemspec
+++ b/lita-jarvis.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "travis"
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "pry-byebug"
+#  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "flores"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"


### PR DESCRIPTION
Fixes #81 

I had a hard time testing the full workflow, so am only 90% sure this fixes the underlying issue. I was able to reproduce the error on an Ubuntu box by breaking the local setting with ```export LC_ALL=en_US``` (which is invalid), and then watch this change resolve that the ```invalid byte sequence in US-ASCII``` error. 

However, I could not get a full workflow tested due to 
```
Failure/Error: pid, stdin, stdout, stderr = Open4::popen4("git", "-C", "#{git.dir}", "am", "--", patch.path)
    NotImplementedError:
       fork is not available on this platform
```

Also, the comment to the gemspec was necessary to get bundler to run, and missing require showed up in my testing the single merge command. 

FWIW, I believe that this issue can also be fixed locally by ensuring the locale is setup for UTF-8.  This change _should_ allow the environment to be what ever, and will always enforce UTF-8. Note - this change may actually beak UTF-16 users. 