### PR TITLE
Bump jruby version from 1.7.25 to 9.1.14.0

### DIFF
--- a/lib/jarvis/exec.rb
+++ b/lib/jarvis/exec.rb
@@ -4,7 +4,7 @@ require "bundler"
 
 module Jarvis
   class SubprocessFailure < ::Jarvis::Error ; end
-  JRUBY_VERSION = "1.7.25"
+  JRUBY_VERSION = "9.1.14.0"
 
   def self.execute(args, logger, directory=nil)
     logger.info("Running command", :args => args)


### PR DESCRIPTION
We now mostly work on 9k, so let's reflect that with a modern jruby.