### PR TITLE
@jarvis exec URL rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
-gem "lita-slack"
-gem "lita", git: "https://github.com/jordansissel/lita", branch: "user-metadata-deletes"
 gemspec

--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -18,7 +18,8 @@ module Jarvis module Command class Publish < Clamp::Command
   banner "Publish a logstash plugin"
 
   option "--workdir", "WORKDIR", "The place where this command will download temporary files and do stuff on disk to complete a given task."
-  option "--[no-]check-build", :flag, "Don't check if the build pass on jenkins and try to publish anyway", :default => true#, :attribute_name => :check_build
+  option "--env", "ENV", "ENV variables passed to publish task.", :default => 'JARVIS=true LOGSTASH_SOURCE=false' # to be able to bundle wout LS
+  option "--[no-]check-build", :flag, "Don't check if the build pass on jenkins and try to publish anyway", :default => true
 
   parameter "PROJECT", "The project URL" do |url|
     Jarvis::GitHub::Project.parse(url)
@@ -44,7 +45,7 @@ module Jarvis module Command class Publish < Clamp::Command
 
     logger.info("Cloning repo", :url => project.git_url)
     git = Jarvis::Git.clone_repo(project.git_url, workdir)
-    
+
     puts I18n.t("lita.handlers.jarvis.publish",
                 :organization => project.organization,
                 :project => project.name,
@@ -100,7 +101,7 @@ module Jarvis module Command class Publish < Clamp::Command
         if condition.call(workdir)
           context[:command] = command
           puts I18n.t("lita.handlers.jarvis.publish command", :command => command)
-          Jarvis.execute(command, logger, git.dir)
+          Jarvis.execute(command, logger, git.dir, env)
 
           # Clear the logs if it was successful
           logs.clear unless logger.debug?

--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -76,7 +76,7 @@ module Jarvis module Command class Publish < Clamp::Command
         end
 
         if current_states.keys.grep(/continuous-integration\/travis-ci\/.+/).any?
-          logger.info("(freddie) Successful Travis run detected!")
+          logger.info(":freddie: Successful Travis run detected!")
         else
           logger.warn("No travis status found for this commit! Will fall back to jenkins")
 

--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -28,8 +28,8 @@ module Jarvis module Command class Publish < Clamp::Command
   ALWAYS_RUN = lambda { |workdir| true }
 
   TASKS = { "bundle install" => ALWAYS_RUN,
-            "bundle exec rake vendor" => ALWAYS_RUN,
-            "bundle exec rake publish_gem" => ALWAYS_RUN }.freeze
+            "ruby -rbundler/setup -S rake vendor" => ALWAYS_RUN,
+            "ruby -rbundler/setup -S rake publish_gem" => ALWAYS_RUN }.freeze
 
   NO_PREVIOUS_GEMS_PUBLISHED = "This rubygem could not be found."
 

--- a/lib/jarvis/commands/run.rb
+++ b/lib/jarvis/commands/run.rb
@@ -1,0 +1,59 @@
+require "clamp"
+require "stud/temporary"
+require "jarvis/exec"
+require "jarvis/github/project"
+
+module Jarvis module Command class Run < Clamp::Command
+  banner "Execute a command against a repository (kind of like bundle exec ...)"
+
+  option "--workdir", "WORKDIR", "The place where this command will download temporary files and do stuff on disk to complete a given task."
+  option "--env", "ENV", "ENV variables passed to task.", :default => 'JARVIS=true LOGSTASH_SOURCE=false' # to be able to bundle wout LS
+  option "--branch", "BRANCH", "The branch to run from.", :default => 'master'
+
+  parameter "PROJECT", "The project URL" do |url|
+    Jarvis::GitHub::Project.parse(url)
+  end
+  parameter "SCRIPT ...", "The script runner", :attribute_name => :script
+
+  def execute
+    self.workdir = Stud::Temporary.pathname if workdir.nil?
+
+    logs = []
+    logger = ::Cabin::Channel.new
+    logger.subscribe(logs)
+    logger.subscribe(STDOUT)
+    logger.level = :info
+
+    logger.info("Cloning repo", :url => project.git_url)
+    git = Jarvis::Git.clone_repo(project.git_url, workdir)
+
+    task = "#{script.join(' ')}"
+    puts ":ninja: Trying to run `#{task}` from #{project.organization}/#{project.name} (branch: #{branch})"
+
+    git.checkout(branch)
+    context = logger.context
+    context[:operation] = 'run'
+    context[:branch] = branch
+
+    commands = [ "bundle install", ["ruby -rbundler/setup -S", *script] ]
+
+    commands.each do |command|
+      context[:command] = command
+      puts I18n.t("lita.handlers.jarvis.publish command", :command => command)
+      Jarvis.execute(command, logger, git.dir, env)
+
+      # Clear the logs if it was successful
+      logs.clear unless logger.debug?
+    end
+    context.clear
+    git.reset
+    git.clean(force: true)
+
+    puts ":success: Finished task `#{task}` from #{project.organization}/#{project.name} (branch: #{branch})"
+
+    puts logs.join("\n")
+  rescue => e
+    puts I18n.t("lita.handlers.jarvis.exception", :exception => e.class, :message => e.to_s, :command => 'run')
+  end
+
+end end end

--- a/lib/jarvis/exec.rb
+++ b/lib/jarvis/exec.rb
@@ -19,8 +19,9 @@ module Jarvis
                                          "cd #{Shellwords.shellescape(directory)}",
                                          ". #{rvm_path}/scripts/rvm",
                                          "echo PWD; pwd",
-                                         "rvm use #{JRUBY_VERSION}; rvm use; #{args}"
+                                         "rvm use #{JRUBY_VERSION}; rvm use"
                                      ]
+                                     cd_rvm_args << Array(args).join(' ')
                                      wrapped = [ 'env', '-' ]
                                      wrapped.concat env_to_shell_lines(execute_env.merge(env))
                                      wrapped.concat [ 'bash', '-c', cd_rvm_args.join('; ') ]

--- a/lib/jarvis/exec.rb
+++ b/lib/jarvis/exec.rb
@@ -10,6 +10,7 @@ module Jarvis
 
   def self.execute(args, logger, directory = nil, env = {})
     logger.info("Running command", :args => args)
+    env = parse_env_string(env) if env.is_a?(String)
     # We have to wrap the command into this block to make sure the current command use his 
     # defined set of gems and not jarvis gems.
     with_dir(directory) do # Bundler.with_clean_env do
@@ -58,6 +59,10 @@ module Jarvis
 
     def env_to_shell_lines(env)
       env.map { |var, val| "#{var}=#{Shellwords.shellescape(val)}" }
+    end
+
+    def parse_env_string(str)
+      str.scan(/\w+=\w+/).map { |s| s.split('=') }.to_h
     end
 
   end

--- a/lib/lita/handlers/heartbeat.rb
+++ b/lib/lita/handlers/heartbeat.rb
@@ -1,8 +1,3 @@
-require "securerandom"
-require "concurrent"
-require "stud/interval"
-require "time"
-
 module Lita
   module Handlers
     class Heartbeat < Handler

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -7,6 +7,7 @@ require "jarvis/commands/cla"
 require "jarvis/commands/publish"
 require "jarvis/commands/teamtime"
 require "jarvis/commands/plugins"
+require "jarvis/commands/run"
 require "jarvis/mixins/fancy_route"
 require "jarvis/thread_logger"
 require "jarvis/commands/review"
@@ -87,6 +88,9 @@ module Lita
       fancy_route("reviews", ::Jarvis::Command::Review, :command => true)
       fancy_route("review", ::Jarvis::Command::Review, :command => true)
       fancy_route("plugins", ::Jarvis::Command::Plugins, :command => true)
+
+      fancy_route("run", ::Jarvis::Command::Run, :command => true)
+      fancy_route("exec", ::Jarvis::Command::Run, :command => true)
 
       Lita.register_handler(self)
     end

--- a/lita-jarvis.gemspec
+++ b/lita-jarvis.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "mustache"
   spec.add_runtime_dependency "octokit"
   spec.add_runtime_dependency "stud"
-  spec.add_runtime_dependency "concurrent-ruby", "0.9.1"
+  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_runtime_dependency "git", "~> 1.2.9"
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "mbox"

--- a/lita-jarvis.gemspec
+++ b/lita-jarvis.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", ">= 4.6"
+  spec.add_runtime_dependency "lita", ">= 4.7"
+  spec.add_runtime_dependency "lita-slack"
   spec.add_runtime_dependency "clamp", "~> 1.0.0"
   spec.add_runtime_dependency "mustache"
   spec.add_runtime_dependency "octokit"

--- a/lita-jarvis.gemspec
+++ b/lita-jarvis.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-jarvis"
-  spec.version       = "0.1.0"
+  spec.version       = "0.3.0"
   spec.authors       = ["Jordan Sissel"]
   spec.email         = ["jls@semicomplete.com"]
   spec.description   = "-"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -18,32 +18,32 @@ en:
             %{key} has no value for your profile.
       heartbeat:
         ping response: >-
-          (chompy) (new jarvis)
+          :chompy: (j.a.r.v.i.s.)
       jarvis:
         merge success: |-
-          (success) Merged %{organization}/%{project}#%{number} into %{branches}
+          :success: Merged %{organization}/%{project}#%{number} into %{branches}
         publish: |-
-          (ninja) Trying to publish %{organization}/%{project} from the following branches: %{branches}
+          :ninja: Trying to publish %{organization}/%{project} from the following branches: %{branches}
         publish command: |-
           Running command: %{command}
         publish success: |-
-          (success) Published %{organization}/%{project}/%{branch}
+          :success: Published %{organization}/%{project}/%{branch}
         exception: |-
-          (sadpanda) An error occurred in %{command}: %{exception} - %{message}
+          :sadpanda: An error occurred in %{command}: %{exception} - %{message}
         unhandled exception: >-
-          (boom) Unhandled exception: %{class} - %{message}
+          :boom: Unhandled exception: %{class} - %{message}
         rejected execution: >-
-          The %{pool} pool is full, so I am too busy to do that work right now, sorry! (shrug)
+          The %{pool} pool is full, so I am too busy to do that work right now, sorry! :shrug:
         user profile error: >-
-          (whoa) %{class}: %{message}.
+          :whoa: %{class}: %{message}.
           You can resolve this by telling me your git email `user set git-email
           your@email-address`. I need this information for setting the git
           committer data during the merge.
         cla:
           failure: |-
-            (failed) %{project}#%{pr} - %{message}
+            :failed: %{project}#%{pr} - %{message}
           success: |-
-            (freddie) %{project}#%{pr} - %{message}
+            :freddie: %{project}#%{pr} - %{message}
 
       test:
         this should not fail the test %{messge}


### PR DESCRIPTION
and also :
- support `--env` for tasks (`{ 'JARVIS' => 'true', 'LOGSTASH_SOURCE' => 'false' }` default)
  we'll probably need this as we switch plugins to require a LS installation from `Gemfile`
- faster (less spawning) `bundle exec ...` 
- let's enjoy :emoji: