### PR TITLE
[WiP] support for Java plugins publishing

### DIFF
--- a/lib/jarvis/exec.rb
+++ b/lib/jarvis/exec.rb
@@ -1,8 +1,6 @@
 require "jarvis/error"
 require "jarvis/env_utils"
-require "bundler"
 require "open4"
-require "tmpdir"
 
 module Jarvis
   extend EnvUtils
@@ -13,29 +11,36 @@ module Jarvis
   def self.execute(args, directory = nil, env = {}, logger = self.logger)
     logger.info("Running command", :args => args) if logger
     env = parse_env_string(env) if env.is_a?(String)
+
+    wrap_args_with_env = lambda do |args|
+      if env.any?
+        wrapped_args = [ 'env', '-' ]
+        wrapped_args.concat env_to_shell_lines(execute_env.merge(env))
+        wrapped_args.concat [ 'bash', '-c', args.join('; ') ]
+        wrapped_args
+      else
+        args
+      end
+    end
+
     # We have to wrap the command into this block to make sure the current command use his 
     # defined set of gems and not jarvis gems.
-    with_dir(directory) do # Bundler.with_clean_env do
-      pid, stdin, stdout, stderr = if directory || env.any?
-                                     cd_rvm_args = [
-                                         "cd #{shell_escape(directory)}",
-                                         ". #{rvm_path}/scripts/rvm",
-                                         "echo PWD; pwd",
-                                         "rvm use #{JRUBY_VERSION}; rvm use"
-                                     ]
-                                     cd_rvm_args << Array(args).join(' ')
-                                     wrapped = [ 'env', '-' ]
-                                     wrapped.concat env_to_shell_lines(execute_env.merge(env))
-                                     wrapped.concat [ 'bash', '-c', cd_rvm_args.join('; ') ]
-                                     Open4::popen4(*wrapped)
-                                   else
-                                     Open4::popen4(*args)
-                                   end
-      stdin.close
-      logger.pipe(stdout => :info, stderr => :error) if logger
-      _, status = Process::waitpid2(pid)
-      raise SubprocessFailure, "subprocess failed with code #{status.exitstatus}" unless status.success?
-    end
+    pid, stdin, stdout, stderr = if directory
+                                   cd_rvm_args = [
+                                       "cd #{shell_escape(directory)}",
+                                       ". #{rvm_path}/scripts/rvm",
+                                       "echo PWD; pwd",
+                                       "rvm use #{JRUBY_VERSION}; rvm use"
+                                   ]
+                                   cd_rvm_args << Array(args).join(' ')
+                                   Open4::popen4 *wrap_args_with_env.(cd_rvm_args)
+                                 else
+                                   Open4::popen4 *wrap_args_with_env.(args)
+                                 end
+    stdin.close
+    logger.pipe(stdout => :info, stderr => :error) if logger
+    _, status = Process::waitpid2(pid)
+    raise SubprocessFailure, "subprocess failed with code #{status.exitstatus}" unless status.success?
   end
 
   def self.logger
@@ -45,14 +50,6 @@ module Jarvis
   class << self
 
     private
-
-    def with_dir(directory, &block)
-      if directory.nil?
-        Dir.mktmpdir(&block)
-      else
-        yield directory
-      end
-    end
 
     def rvm_path
       ENV['rvm_path'] || '~/.rvm'


### PR DESCRIPTION
while deploying from an updated master (https://github.com/elastic/jarvis/pull/100 and others)
noticed that [**java_plugins_publish**](https://github.com/elastic/jarvis/tree/java_plugins_publish) branch might have been used but hasn't been merged.

this might need more testing and work ... 