### PR TITLE
Modify merge command to perform merge on target branch

### DIFF
--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -1,5 +1,6 @@
 require 'jarvis/github'
 require "jarvis/commands/merge"
+require "jarvis/commands/old_merge"
 require "jarvis/commands/status"
 require "jarvis/commands/restart"
 require "jarvis/commands/slowcmd"
@@ -73,6 +74,10 @@ module Lita
       fancy_route("status", ::Jarvis::Command::Status, :command => true, :pool => ::Jarvis::WorkPool::ADMINISTRATIVE)
       fancy_route("slowcmd", ::Jarvis::Command::SlowCommand, :command => true)
       fancy_route("merge", ::Jarvis::Command::Merge, :command => true, :flags => {
+        "--committer-email" => ->(request) { request.user.metadata["git-email"] || raise(::Jarvis::UserProfileError, "Missing user setting `git-email` for user #{request.user.name}") },
+        "--committer-name" => ->(request) { request.user.name }
+      })
+      fancy_route("oldmerge", ::Jarvis::Command::OldMerge, :command => true, :flags => {
         "--committer-email" => ->(request) { request.user.metadata["git-email"] || raise(::Jarvis::UserProfileError, "Missing user setting `git-email` for user #{request.user.name}") },
         "--committer-name" => ->(request) { request.user.name }
       })

--- a/templates/github_merge_comment.mustache
+++ b/templates/github_merge_comment.mustache
@@ -1,7 +1,11 @@
-{{ committer }} merged this into the following branches!
+{{ committer }} merged this to {{ base }}!
+{{#commits.length}}
+
+Pull request was also backported into the following branches:
 
 Branch | Commits
 -------|--------
 {{#commits}}
 {{branch}} | {{commits}}
 {{/commits}}
+{{/commits.length}}

--- a/templates/github_oldmerge_comment.mustache
+++ b/templates/github_oldmerge_comment.mustache
@@ -1,0 +1,7 @@
+{{ committer }} merged this into the following branches!
+
+Branch | Commits
+-------|--------
+{{#commits}}
+{{branch}} | {{commits}}
+{{/commits}}


### PR DESCRIPTION
The merge command has historically treated the list of branches as equals;
we would format-patch the change and then apply it to the list one by one.

This would mean that the github PR would not be marked as merged as we
were creating a new commit. This change modifies that, where the first
branch is merged with a normal git merge, and the remaining branches are
treated as before with 'git am'.

The new merge command will not append a "fixes #pr_number" sentence to
the commit message as it did before. Doing this would create a different
commit preventing the github PR from being marked as merged.

We keep the old command as "oldmerge".

This change also supports an empty branch list as an argument. In this
situation the PR's base branch will be used.

Resolves #54