### PR TITLE
only run plugin test notification on Mondays

### DIFF
--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -14,6 +14,7 @@ require "jarvis/thread_logger"
 require "jarvis/commands/review"
 require "jarvis/github/review_search"
 require "travis"
+require "date"
 
 module Lita
   module Handlers
@@ -33,7 +34,8 @@ module Lita
         Travis.github_auth(config.github_token)
 
         every(60*60) { review_search(robot) }
-        every(6*60*60) { travis_watchdog(robot) }
+        # only run on Mondays, check every day what day is it
+        every(24*60*60) { travis_watchdog(robot) if Date.today.monday? }
       end
 
       def travis_watchdog(robot)


### PR DESCRIPTION
Currently we print to Slack every 6 hours which plugins are broken.
This PR changes this to only print once on Monday. Monday was chosen since Travis usually triggers a test on all plugins every Friday.