### PR TITLE
rename oldmerge command to backport

### DIFF
--- a/lib/jarvis/commands/backport.rb
+++ b/lib/jarvis/commands/backport.rb
@@ -14,7 +14,7 @@ require "jarvis/fetch"
 require "jarvis/defer"
 require "mbox"
 
-module Jarvis module Command class OldMerge < Clamp::Command
+module Jarvis module Command class Backport < Clamp::Command
   include ::Jarvis::Github
 
   Encoding.default_external = Encoding::UTF_8
@@ -23,14 +23,14 @@ module Jarvis module Command class OldMerge < Clamp::Command
   class PushFailure < ::Jarvis::Error; end
   class Bug < ::Jarvis::Error; end
 
-  banner "Merge a pull request into one or more branches. Uses 'git am' on all branches."
+  banner "Backport a pull request into one or more branches. Uses 'git am'."
 
   option "--committer-email", "EMAIL", "The git committer to set on all commits. If not set, the default is whatever your git defaults to (see `git config --get user.email` and `git config --get user.email`)."
   option "--committer-name", "NAME", "The git committer name to set on all commits. If not set, the default is whatever your git defaults to (see `git config --get user.name` and `git config --get user.email`)."
 
   option "--workdir", "WORKDIR", "The place where this command will download temporary files and do stuff on disk to complete a given task."
 
-  parameter "PR", "The PR URL to merge" do |url|
+  parameter "PR", "The PR URL to backport" do |url|
     Jarvis::GitHub::PullRequest.parse(url)
   end
 
@@ -84,7 +84,7 @@ module Jarvis module Command class OldMerge < Clamp::Command
         ::Jarvis::Git.apply_mail(git, mail, logger) do |description|
           # Append the 'Fixes #1234' to the bottom of the commit message for
           # whatever PR this is..
-          description + "\nFixes \##{pr.number}"
+          description + "\nBackport of \##{pr.number} to #{branch}"
         end
 
         # Verify the committer is set correctly.
@@ -101,7 +101,7 @@ module Jarvis module Command class OldMerge < Clamp::Command
       logger[:branch] = nil
     end
 
-    template = File.join(File.dirname(__FILE__), "..", "..", "..", "templates", "github_oldmerge_comment.mustache")
+    template = File.join(File.dirname(__FILE__), "..", "..", "..", "templates", "github_backport_comment.mustache")
     comment = Mustache.render(File.read(template),
                               :committer => committer_name,
                               :commits => commits.each { |v| v[:commits] = v[:commits].join(", ") })

--- a/lib/lita/handlers/jarvis.rb
+++ b/lib/lita/handlers/jarvis.rb
@@ -1,6 +1,6 @@
 require 'jarvis/github'
 require "jarvis/commands/merge"
-require "jarvis/commands/old_merge"
+require "jarvis/commands/backport"
 require "jarvis/commands/status"
 require "jarvis/commands/restart"
 require "jarvis/commands/slowcmd"
@@ -79,7 +79,7 @@ module Lita
         "--committer-email" => ->(request) { request.user.metadata["git-email"] || raise(::Jarvis::UserProfileError, "Missing user setting `git-email` for user #{request.user.name}") },
         "--committer-name" => ->(request) { request.user.name }
       })
-      fancy_route("oldmerge", ::Jarvis::Command::OldMerge, :command => true, :flags => {
+      fancy_route("backport", ::Jarvis::Command::Backport, :command => true, :flags => {
         "--committer-email" => ->(request) { request.user.metadata["git-email"] || raise(::Jarvis::UserProfileError, "Missing user setting `git-email` for user #{request.user.name}") },
         "--committer-name" => ->(request) { request.user.name }
       })

--- a/templates/github_backport_comment.mustache
+++ b/templates/github_backport_comment.mustache
@@ -1,4 +1,4 @@
-{{ committer }} merged this into the following branches!
+{{ committer }} backported this into the following branches!
 
 Branch | Commits
 -------|--------


### PR DESCRIPTION
Use the 'backport' command to perform a git am of the PRs commits into one or more branches.

A comment will be made in the PR about the backport, which you can see an example of here: https://github.com/jsvd/test-repo/pull/18#issuecomment-637423446

Also, each commit will reference that it's part of a backport in the format of "Backport of #PR_number to <branch>", example here: https://github.com/jsvd/test-repo/commit/689c978a267e7c689ecd5303be2f1c1d5e186564