### PR TITLE
Bump LS version used when resolving dependencies

### DIFF
--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -20,7 +20,7 @@ module Jarvis module Command class Publish < Clamp::Command
   banner "Publish a logstash plugin"
 
   option "--workdir", "WORKDIR", "The place where this command will download temporary files and do stuff on disk to complete a given task."
-  option "--env", "ENV", "ENV variables passed to publish task.", :default => 'JARVIS=true LOGSTASH_SOURCE=1 LOGSTASH_PATH=RELEASE@6.5.4'
+  option "--env", "ENV", "ENV variables passed to publish task.", :default => 'JARVIS=true LOGSTASH_SOURCE=1 LOGSTASH_PATH=RELEASE@6.8.0'
   option "--[no-]check-build", :flag, "Don't check if the build pass on jenkins and try to publish anyway", :default => true
 
   parameter "PROJECT", "The project URL" do |url|


### PR DESCRIPTION
... as [some](https://github.com/logstash-plugins/logstash-input-elasticsearch/blob/v4.9.0/logstash-input-elasticsearch.gemspec#L23) plugins now have [dependencies that are only supporting LS 6.8](https://github.com/logstash-plugins/logstash-mixin-validator_support/blob/v1.0.1/logstash-mixin-validator_support.gemspec#L23)

LS is resolved during `bundle install` which is a prerequisite for running the publish task, having a (default) version < 6.8 will cause a resolution failure and the task to fail.