### PR TITLE
Dockerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN set -x && \
     apt update && \
     apt install -y ruby ruby-dev build-essential git
 
+# MRI symlinked to /usr/bin/ruby (-> ruby2.5)
+
 # Due (old) EventMachine we need to OpenSSL 1.0 bits
 WORKDIR /tmp
 RUN wget http://deb.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2u-1~deb9u1_amd64.deb
@@ -20,16 +22,16 @@ RUN echo 'gem: --no-document' >> /etc/gemrc
 
 RUN /usr/bin/ruby -S gem install bundler -v '~> 2.1.4'
 
-# Create jarvis (non-root) user for running the Ruby process
-RUN addgroup --gid 1000 jarvis && \
-    adduser --uid 1000 --gid 1000 --gecos "" --disabled-password jarvis
-
 # Download Logstash to a known location to keep the image self-contained, instead of downloading on demand
 # e.g. plugin publishing will than reference LOGSTASH_PATH=/usr/share/logstash by default
 WORKDIR /usr/share
 RUN wget https://artifacts.elastic.co/downloads/logstash/logstash-6.8.17.tar.gz
 RUN tar -xzf logstash-6.8.17.tar.gz && rm logstash-6.8.17.tar.gz
 RUN ln -s logstash-6.8.17 logstash
+
+# Create jarvis (non-root) user for running the Ruby process
+RUN addgroup --gid 1000 jarvis && \
+    adduser --uid 1000 --gid 1000 --gecos "" --disabled-password jarvis
 
 COPY --chown=jarvis:jarvis Gemfile* *.gemspec /usr/share/jarvis/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ USER jarvis
 WORKDIR /usr/share/jarvis
 RUN /usr/bin/ruby -S bundle install --deployment
 
-COPY --chown=jarvis:jarvis * /usr/share/jarvis/
+COPY --chown=jarvis:jarvis . /usr/share/jarvis/
 
 # Restore system ruby to JRuby
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,5 +69,9 @@ COPY --chown=jarvis:jarvis . /usr/share/jarvis/
 # PWD=/usr/share/jarvis
 
 USER jarvis
+
+# git (ssh) commands should be able to authenticate with github.com
+RUN mkdir ~/.ssh && ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+
 WORKDIR /usr/share/jarvis
 CMD /usr/bin/ruby bin/lita start --config lita_config.docker.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,14 @@ RUN set -x && \
     apt update && \
     apt install -y ruby ruby-dev build-essential git redis-server
 
+RUN sed -i 's/bind 127.0.0.1 ::1/#bind 127.0.0.1/g' /etc/redis/redis.conf
+#RUN cat /etc/redis/redis.conf
+# WiP
+RUN /etc/init.d/redis-server restart
+RUN sleep 1
+RUN /etc/init.d/redis-server status
+#RUN ss -an | grep 6379
+
 # Due (old) EventMachine we need to OpenSSL 1.0 bits
 WORKDIR /tmp
 RUN wget http://deb.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2u-1~deb9u1_amd64.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,13 +30,16 @@ USER jarvis
 WORKDIR /usr/share/jarvis
 RUN /usr/bin/ruby -S bundle install --deployment
 
-COPY --chown=jarvis:jarvis . /usr/share/jarvis/
-
 # Restore system ruby to JRuby
 USER root
 RUN update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
 
 ENV JRUBY_OPTS="--dev -J-Xmx1g"
+
+# We also assume Bundler installed for commands run by Jarvis
+RUN /opt/jruby/bin/jruby -S gem install bundler -v '~> 2.1.4'
+
+COPY --chown=jarvis:jarvis . /usr/share/jarvis/
 
 USER jarvis
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jruby:9.2.19.0-jre11
+FROM jruby:9.2.19.0-jdk11
 
 # JRuby available at /opt/jruby/bin/jruby
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,4 @@ USER jarvis
 # JAVA_HOME=/usr/local/openjdk-11
 # PWD=/usr/share/jarvis
 
-CMD /usr/bin/ruby -rbundler/setup -S lita start --config /usr/share/jarvis/lita_config.docker.rb
+CMD /usr/bin/ruby bin/lita start --config lita_config.docker.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,15 @@ RUN /usr/bin/ruby -S gem install bundler -v '~> 2.1.4'
 RUN addgroup --gid 1000 jarvis && \
     adduser --uid 1000 --gid 1000 --gecos "" --disabled-password jarvis
 
-COPY --chown=jarvis:jarvis * /usr/share/jarvis/
+COPY --chown=jarvis:jarvis Gemfile* *.gemspec /usr/share/jarvis/
 
 USER jarvis
 WORKDIR /usr/share/jarvis
 RUN /usr/bin/ruby -S bundle install --deployment
 
-# Restore system ruby being JRuby
+COPY --chown=jarvis:jarvis * /usr/share/jarvis/
+
+# Restore system ruby to JRuby
 USER root
 RUN update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
 
@@ -55,3 +57,5 @@ USER jarvis
 # GEM_HOME=/usr/local/bundle
 # JAVA_HOME=/usr/local/openjdk-11
 # PWD=/usr/share/jarvis
+
+CMD /usr/bin/ruby -rbundler/setup -S lita start --config /usr/share/jarvis/lita_config.docker.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM jruby:9.2.19.0-jre11
+
+# JRuby available at /opt/jruby/bin/jruby
+
+RUN set -x && \
+    apt update && \
+    apt install -y ruby ruby-dev build-essential git
+
+# MRI symlinked to /usr/bin/ruby (-> ruby2.5)
+
+RUN echo 'gem: --no-document' >> /etc/gemrc
+
+RUN /usr/bin/ruby -S gem install bundler -v '~> 1.17.3'
+
+# Create jarvis (non-root) user for running the Ruby process
+RUN addgroup --gid 1000 jarvis && \
+    adduser --uid 1000 --gid 1000 --gecos "" --disabled-password jarvis
+
+COPY --chown=jarvis:jarvis * /usr/share/jarvis/
+
+USER jarvis
+WORKDIR /usr/share/jarvis
+RUN /usr/bin/ruby -S bundle install --deployment
+
+# Restore system ruby being JRuby
+USER root
+RUN update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
+
+ENV JRUBY_OPTS="--dev -J-Xmx1g"
+
+USER jarvis
+
+#RUN ruby -v
+# jruby 9.2.19.0 (2.5.8) 2021-06-15 55810c552b OpenJDK 64-Bit Server VM 11.0.11+9 on 11.0.11+9 [linux-x86_64]
+
+#RUN env
+# JRUBY_VERSION=9.2.19.0
+# HOSTNAME=d80ab642f6dc
+# HOME=/home/jarvis
+# LANG=C.UTF-8
+# BUNDLE_APP_CONFIG=/usr/local/bundle
+# BUNDLE_SILENCE_ROOT_WARNING=1
+# JRUBY_OPTS=--dev -J-Xmx1g
+# JAVA_VERSION=11.0.11+9
+# PATH=/usr/local/bundle/bin:/opt/jruby/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# JRUBY_SHA256=1f74885a2d3fa589fcbeb292a39facf7f86be3eac1ab015e32c65d32acf3f3bf
+# GEM_HOME=/usr/local/bundle
+# JAVA_HOME=/usr/local/openjdk-11
+# PWD=/usr/share/jarvis

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,14 @@ RUN set -x && \
     apt update && \
     apt install -y ruby ruby-dev build-essential git
 
+# Due (old) EventMachine we need to OpenSSL 1.0 bits
+WORKDIR /tmp
+RUN wget http://deb.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2u-1~deb9u1_amd64.deb
+RUN dpkg -i libssl1.0.2_1.0.2u-1~deb9u1_amd64.deb
+RUN wget http://deb.debian.org/debian/pool/main/o/openssl1.0/libssl1.0-dev_1.0.2u-1~deb9u1_amd64.deb
+RUN dpkg -i libssl1.0-dev_1.0.2u-1~deb9u1_amd64.deb
+RUN rm /tmp/*.deb
+
 # MRI symlinked to /usr/bin/ruby (-> ruby2.5)
 
 RUN echo 'gem: --no-document' >> /etc/gemrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x && \
 
 RUN echo 'gem: --no-document' >> /etc/gemrc
 
-RUN /usr/bin/ruby -S gem install bundler -v '~> 1.17.3'
+RUN /usr/bin/ruby -S gem install bundler -v '~> 2.1.4'
 
 # Create jarvis (non-root) user for running the Ruby process
 RUN addgroup --gid 1000 jarvis && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM jruby:9.2.19.0-jre11
 
 RUN set -x && \
     apt update && \
-    apt install -y ruby ruby-dev build-essential git
+    apt install -y ruby ruby-dev build-essential git redis-server
 
 # Due (old) EventMachine we need to OpenSSL 1.0 bits
 WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,7 @@ FROM jruby:9.2.19.0-jdk11
 
 RUN set -x && \
     apt update && \
-    apt install -y ruby ruby-dev build-essential git redis-server
-
-RUN sed -i 's/bind 127.0.0.1 ::1/#bind 127.0.0.1/g' /etc/redis/redis.conf
-#RUN cat /etc/redis/redis.conf
-# WiP
-RUN /etc/init.d/redis-server restart
-RUN sleep 1
-RUN /etc/init.d/redis-server status
-#RUN ss -an | grep 6379
+    apt install -y ruby ruby-dev build-essential git
 
 # Due (old) EventMachine we need to OpenSSL 1.0 bits
 WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,13 @@ RUN /usr/bin/ruby -S gem install bundler -v '~> 2.1.4'
 RUN addgroup --gid 1000 jarvis && \
     adduser --uid 1000 --gid 1000 --gecos "" --disabled-password jarvis
 
+# Download Logstash to a known location to keep the image self-contained, instead of downloading on demand
+# e.g. plugin publishing will than reference LOGSTASH_PATH=/usr/share/logstash by default
+WORKDIR /usr/share
+RUN wget https://artifacts.elastic.co/downloads/logstash/logstash-6.8.17.tar.gz
+RUN tar -xzf logstash-6.8.17.tar.gz && rm logstash-6.8.17.tar.gz
+RUN ln -s logstash-6.8.17 logstash
+
 COPY --chown=jarvis:jarvis Gemfile* *.gemspec /usr/share/jarvis/
 
 USER jarvis
@@ -40,8 +47,6 @@ ENV JRUBY_OPTS="--dev -J-Xmx1g"
 RUN /opt/jruby/bin/jruby -S gem install bundler -v '~> 2.1.4'
 
 COPY --chown=jarvis:jarvis . /usr/share/jarvis/
-
-USER jarvis
 
 #RUN ruby -v
 # jruby 9.2.19.0 (2.5.8) 2021-06-15 55810c552b OpenJDK 64-Bit Server VM 11.0.11+9 on 11.0.11+9 [linux-x86_64]
@@ -61,4 +66,6 @@ USER jarvis
 # JAVA_HOME=/usr/local/openjdk-11
 # PWD=/usr/share/jarvis
 
+USER jarvis
+WORKDIR /usr/share/jarvis
 CMD /usr/bin/ruby bin/lita start --config lita_config.docker.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,237 @@
+PATH
+  remote: .
+  specs:
+    lita-jarvis (0.4.0)
+      cabin
+      clamp (~> 1.0.0)
+      concurrent-ruby (~> 1.0)
+      down
+      faraday
+      faraday_middleware
+      gems
+      git (~> 1.2.9)
+      lita (>= 4.7)
+      lita-hipchat
+      lita-slack
+      mbox
+      mustache
+      octokit
+      open4
+      rfc2047
+      stud
+      travis
+      tzinfo
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.2.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    cabin (0.9.0)
+    call-me (0.0.2.3)
+      refining
+    clamp (1.0.1)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.9)
+    diff-lcs (1.4.4)
+    down (5.2.2)
+      addressable (~> 2.5)
+    eventmachine (1.2.7)
+    faraday (1.5.1)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
+    faye-websocket (0.11.1)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.5.1)
+    ffi (1.15.3)
+    flores (0.0.7)
+    formatador (0.3.0)
+    gems (1.2.0)
+    gh (0.18.0)
+      activesupport (~> 5.0)
+      addressable (~> 2.4)
+      faraday (~> 1.0)
+      faraday_middleware (~> 1.0)
+      multi_json (~> 1.0)
+      net-http-persistent (~> 2.9)
+      net-http-pipeline
+    git (1.2.9.1)
+    guard (2.17.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-bundler (2.2.1)
+      bundler (>= 1.3.0, < 3)
+      guard (~> 2.2)
+      guard-compat (~> 1.1)
+    guard-compat (1.2.1)
+    guard-process (1.2.1)
+      guard-compat (~> 1.2, >= 1.2.1)
+      spoon (~> 0.0.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    highline (2.0.3)
+    http_router (0.11.2)
+      rack (>= 1.0.0)
+      url_mount (~> 0.2.1)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
+    json (2.5.1)
+    json_pure (2.5.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    listen (3.5.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    lita (4.7.1)
+      bundler (>= 1.3)
+      faraday (>= 0.8.7)
+      http_router (>= 0.11.2)
+      i18n (>= 0.6.9)
+      ice_nine (>= 0.11.0)
+      multi_json (>= 1.7.7)
+      puma (>= 2.7.1)
+      rack (>= 1.5.2, < 2.0.0)
+      rb-readline (>= 0.5.1)
+      redis-namespace (>= 1.3.0)
+      thor (>= 0.18.1)
+    lita-hipchat (3.0.2)
+      lita (>= 4.4.3)
+      xmpp4r (>= 0.5.6)
+    lita-slack (1.8.0)
+      eventmachine
+      faraday
+      faye-websocket (>= 0.8.0)
+      lita (>= 4.7.1)
+      multi_json
+    lumberjack (1.2.8)
+    mbox (0.1.0)
+      call-me
+    method_source (1.0.0)
+    minitest (5.14.4)
+    multi_json (1.15.0)
+    multipart-post (2.1.1)
+    mustache (1.1.1)
+    nenv (0.3.0)
+    net-http-persistent (2.9.4)
+    net-http-pipeline (1.0.1)
+    nio4r (2.5.7)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    octokit (4.21.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    open4 (1.3.4)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (4.0.6)
+    puma (5.3.2)
+      nio4r (~> 2.0)
+    pusher-client (0.6.2)
+      json
+      websocket (~> 1.0)
+    rack (1.6.13)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rake (13.0.6)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rb-readline (0.5.5)
+    redis (4.3.1)
+    redis-namespace (1.8.1)
+      redis (>= 3.0.4)
+    refining (0.0.5.5)
+    rfc2047 (0.3)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rspec-wait (0.0.9)
+      rspec (>= 3, < 4)
+    ruby2_keywords (0.0.4)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
+    shellany (0.0.1)
+    spoon (0.0.6)
+      ffi
+    stud (0.0.23)
+    thor (1.1.0)
+    thread_safe (0.3.6)
+    travis (1.10.0)
+      faraday (~> 1.0)
+      faraday_middleware (~> 1.0)
+      gh (~> 0.13)
+      highline (~> 2.0)
+      json_pure (~> 2.3)
+      launchy (~> 2.1, < 2.5.0)
+      pusher-client (~> 0.4)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
+    url_mount (0.2.1)
+      rack
+    websocket (1.2.9)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    xmpp4r (0.5.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.3)
+  flores
+  guard
+  guard-bundler
+  guard-process
+  guard-rspec
+  lita-jarvis!
+  rack-test
+  rake
+  rspec (>= 3.0.0)
+  rspec-wait
+
+BUNDLED WITH
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       faraday_middleware
       gems
       git (~> 1.2.9)
-      lita (>= 4.7)
+      lita (~> 4.8)
       lita-hipchat
       lita-slack
       mbox
@@ -86,8 +86,8 @@ GEM
       pry (>= 0.9.12)
       shellany (~> 0.0)
       thor (>= 0.18.1)
-    guard-bundler (2.2.1)
-      bundler (>= 1.3.0, < 3)
+    guard-bundler (3.0.0)
+      bundler (>= 2.1, < 3)
       guard (~> 2.2)
       guard-compat (~> 1.1)
     guard-compat (1.2.1)
@@ -112,18 +112,18 @@ GEM
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    lita (4.7.1)
-      bundler (>= 1.3)
-      faraday (>= 0.8.7)
-      http_router (>= 0.11.2)
-      i18n (>= 0.6.9)
-      ice_nine (>= 0.11.0)
-      multi_json (>= 1.7.7)
-      puma (>= 2.7.1)
-      rack (>= 1.5.2, < 2.0.0)
-      rb-readline (>= 0.5.1)
-      redis-namespace (>= 1.3.0)
-      thor (>= 0.18.1)
+    lita (4.8.0)
+      bundler (>= 2.0)
+      faraday (>= 1.0)
+      http_router (>= 0.11)
+      i18n (>= 1.8)
+      ice_nine (>= 0.11)
+      multi_json (>= 1.15)
+      puma (>= 4.3)
+      rack (>= 2.2)
+      rb-readline (>= 0.5)
+      redis-namespace (>= 1.7)
+      thor (>= 1.0)
     lita-hipchat (3.0.2)
       lita (>= 4.4.3)
       xmpp4r (>= 0.5.6)
@@ -161,7 +161,7 @@ GEM
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
-    rack (1.6.13)
+    rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (13.0.6)
@@ -221,7 +221,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.3)
   flores
   guard
   guard-bundler
@@ -234,4 +233,4 @@ DEPENDENCIES
   rspec-wait
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ Lita.configure do |config|
 end
 ```
 
+### Running with Docker
+
+1. Build the image `docker build -t jarvis:0.4.0 .`
+
+2. Running the image requires 3 environmental variables for full functionality.
+   - **GITHUB_TOKEN** access token (from https://github.com/settings/tokens)
+   - **SLACK_TOKEN** https://api.slack.com/authentication/token-types#legacy_bot 
+   - **GEM_HOST_API_KEY** the `rubygems_api_key` for pushing gems to rubygems.org
+
+   `docker run -d --env GITHUB_TOKEN=abcdef --env SLACK_TOKEN=ghijkl --env GEM_HOST_API_KEY=mnoprs jarvis:0.4.0`
+
 ## Contributing
 
 Patches, ideas, and bug reports welcome. :)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ sufficient.
 
 You'll probably want a `lita_config.rb` if you want to have this connect to
 Slack. The following is an example lita configuration. Put this in a file
-called `lita_config.rb` in your git clone of this repo. You'll need to edit it to add github, slack, and other credential information. 
+called `lita_config.rb` in your git clone of this repo. You'll need to edit it to add github, slack, and other credential information.
 
 DO NOT ADD THIS FILE TO GIT. It is too easy to accidentally commit credentials to git, and public git is not the right place to store credentials ;)
 
@@ -59,14 +59,20 @@ end
 
 ### Running with Docker
 
-1. Build the image `docker build -t jarvis:0.4.0 .`
+0. Jarvis requires Redis (running on localhost:6379) as a pre-requisite!
+
+1. Build the image `docker build -t jarvis:0.X.0 .`
 
 2. Running the image requires 3 environmental variables for full functionality.
    - **GITHUB_TOKEN** access token (from https://github.com/settings/tokens)
    - **SLACK_TOKEN** https://api.slack.com/authentication/token-types#legacy_bot 
    - **GEM_HOST_API_KEY** the `rubygems_api_key` for pushing gems to rubygems.org
 
-   `docker run -d --env GITHUB_TOKEN=abcdef --env SLACK_TOKEN=ghijkl --env GEM_HOST_API_KEY=mnoprs jarvis:0.4.0`
+   `docker run -d --env GITHUB_TOKEN=abcdef --env SLACK_TOKEN=ghijkl --env GEM_HOST_API_KEY=mnoprs --net=host jarvis:0.X.0`
+
+Alternatively use the **docker-compose.yml** sample if Redis is not available locally:
+
+   e.g. `docker-compose --env-file ./.env.local up --build`
 
 ## Contributing
 

--- a/bin/lita
+++ b/bin/lita
@@ -5,8 +5,4 @@ require 'bundler/setup'
 require 'lita'
 require 'lita/cli'
 
-# HACK around Lita trying to localize too much ...
-# I18n::MissingTranslation: translation missing: C.UTF-8.lita.config.type_error
-I18n.default_locale = Lita.default_locale = :en
-
 Lita::CLI.start

--- a/bin/lita
+++ b/bin/lita
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+
+require 'lita'
+require 'lita/cli'
+
+Lita::CLI.start

--- a/bin/lita
+++ b/bin/lita
@@ -5,4 +5,8 @@ require 'bundler/setup'
 require 'lita'
 require 'lita/cli'
 
+# HACK around Lita trying to localize too much ...
+# I18n::MissingTranslation: translation missing: C.UTF-8.lita.config.type_error
+I18n.default_locale = Lita.default_locale = :en
+
 Lita::CLI.start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+
+  jarvis:
+    build:
+      context: .
+    tty: true
+    environment:
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - SLACK_TOKEN=${SLACK_TOKEN}
+      - GEM_HOST_API_KEY=${GEM_HOST_API_KEY}
+    network_mode: host
+
+  redis:
+    image: docker.io/bitnami/redis:6.0
+    container_name: redis-server
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_AOF_ENABLED=no
+      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+    ports:
+      - '6379:6379'

--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -30,7 +30,7 @@ module Jarvis module Command class Publish < Clamp::Command
 
   ALWAYS_RUN = lambda { |workdir| true }
 
-  TASKS = { "bundle install" => ALWAYS_RUN,
+  TASKS = { "ruby -S bundle install" => ALWAYS_RUN,
             "ruby -rbundler/setup -S rake vendor" => ALWAYS_RUN,
             "ruby -rbundler/setup -S rake publish_gem" => ALWAYS_RUN }.freeze
 

--- a/lib/jarvis/commands/publish.rb
+++ b/lib/jarvis/commands/publish.rb
@@ -20,7 +20,7 @@ module Jarvis module Command class Publish < Clamp::Command
   banner "Publish a logstash plugin"
 
   option "--workdir", "WORKDIR", "The place where this command will download temporary files and do stuff on disk to complete a given task."
-  option "--env", "ENV", "ENV variables passed to publish task.", :default => 'JARVIS=true LOGSTASH_SOURCE=1 LOGSTASH_PATH=RELEASE@6.8.0'
+  option "--env", "ENV", "ENV variables passed to publish task.", :default => 'JARVIS=true LOGSTASH_SOURCE=1 LOGSTASH_PATH=/usr/share/logstash'
   option "--[no-]check-build", :flag, "Don't check if the build pass on jenkins and try to publish anyway", :default => true
 
   parameter "PROJECT", "The project URL" do |url|

--- a/lib/jarvis/commands/run.rb
+++ b/lib/jarvis/commands/run.rb
@@ -47,7 +47,7 @@ module Jarvis module Command class Run < Clamp::Command
     context[:operation] = 'run'
     context[:branch] = branch
 
-    commands = [ "bundle install", ["ruby -rbundler/setup -S", *script] ]
+    commands = [ "ruby -S bundle install", ["ruby -rbundler/setup -S", *script] ]
 
     commands.each do |command|
       context[:command] = command

--- a/lita-jarvis.gemspec
+++ b/lita-jarvis.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-jarvis"
-  spec.version       = "0.3.0"
+  spec.version       = "0.4.0"
   spec.authors       = ["Jordan Sissel"]
   spec.email         = ["jls@semicomplete.com"]
   spec.description   = "-"
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "down"
 
   spec.add_development_dependency "bundler", "~> 1.3"
-#  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "flores"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"

--- a/lita-jarvis.gemspec
+++ b/lita-jarvis.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", ">= 4.7"
+  spec.add_runtime_dependency "lita", "~> 4.8"
   spec.add_runtime_dependency "lita-slack"
   spec.add_runtime_dependency "clamp", "~> 1.0.0"
   spec.add_runtime_dependency "mustache"
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "travis"
   spec.add_runtime_dependency "down"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "flores"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"

--- a/lita_config.dev.rb
+++ b/lita_config.dev.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'lita-slack'
+require 'lita'
 
 # Start the bot locally using:
 #
@@ -18,10 +18,11 @@ Lita.configure do |config|
   config.http.host = "127.0.0.1"
 
   if ENV["SLACK_TOKEN"]
+    require 'lita-slack'
     # Go to https://my.slack.com/services/new/bot and make a new bot
     # You will interact directly via slack
     config.robot.adapter = :slack
-    config.adapters.slack.token = ENV["SLACK_TOKEN"] || ''
+    config.adapters.slack.token = ENV["SLACK_TOKEN"]
   else
     config.robot.adapter = :shell
   end

--- a/lita_config.dev.rb
+++ b/lita_config.dev.rb
@@ -1,3 +1,11 @@
+# encoding: utf-8
+
+require 'lita-slack'
+
+# Start the bot locally using:
+#
+#   bundle exec lita start -c lita_config.dev.rb
+#
 Lita.configure do |config|
   config.robot.name = "Jarvis"
   config.robot.locale = :en
@@ -6,11 +14,15 @@ Lita.configure do |config|
   config.handlers.jarvis.cla_url = ""
   # Generate at https://github.com/settings/tokens
   # Will need the 'repo' scope and all sub-perms added
-  config.handlers.jarvis.github_token = ""
+  config.handlers.jarvis.github_token = ENV['GITHUB_TOKEN'] || ''
   config.http.host = "127.0.0.1"
 
-  config.robot.adapter = :slack
-  # Go to https://my.slack.com/services/new/bot and make a new bot
-  # You will interact directly via slack
-  config.adapters.slack.token = ""
+  if ENV["SLACK_TOKEN"]
+    # Go to https://my.slack.com/services/new/bot and make a new bot
+    # You will interact directly via slack
+    config.robot.adapter = :slack
+    config.adapters.slack.token = ENV["SLACK_TOKEN"] || ''
+  else
+    config.robot.adapter = :shell
+  end
 end

--- a/lita_config.dev.rb
+++ b/lita_config.dev.rb
@@ -2,13 +2,17 @@
 
 require 'lita'
 
+# HACK around Lita trying to localize too much ...
+# I18n::MissingTranslation: translation missing: C.UTF-8.lita.config.type_error
+I18n.default_locale = Lita.default_locale = :en
+
 # Start the bot locally using:
 #
 #   bundle exec lita start -c lita_config.dev.rb
 #
 Lita.configure do |config|
   config.robot.name = "Jarvis"
-  config.robot.default_locale = :en
+  #config.robot.locale = :en
   config.robot.log_level = :info
 
   config.handlers.jarvis.cla_url = ""

--- a/lita_config.dev.rb
+++ b/lita_config.dev.rb
@@ -8,7 +8,7 @@ require 'lita'
 #
 Lita.configure do |config|
   config.robot.name = "Jarvis"
-  config.robot.locale = :en
+  config.robot.default_locale = :en
   config.robot.log_level = :info
 
   config.handlers.jarvis.cla_url = ""

--- a/lita_config.docker.rb
+++ b/lita_config.docker.rb
@@ -1,5 +1,8 @@
 # encoding: utf-8
 
+require 'lita'
+require 'lita-slack'
+
 # Configuration template, usable for production.
 # @note used during the Docker image generation
 Lita.configure do |config|

--- a/lita_config.docker.rb
+++ b/lita_config.docker.rb
@@ -3,11 +3,15 @@
 require 'lita'
 require 'lita-slack'
 
+# HACK around Lita trying to localize too much ...
+# I18n::MissingTranslation: translation missing: C.UTF-8.lita.config.type_error
+I18n.default_locale = Lita.default_locale = :en
+
 # Configuration template, usable for production.
 # @note used during the Docker image generation
 Lita.configure do |config|
   config.robot.name = "Jarvis"
-  config.robot.default_locale = :en
+  #config.robot.locale = :en
   config.robot.log_level = :info
 
   config.handlers.jarvis.cla_url = ""

--- a/lita_config.docker.rb
+++ b/lita_config.docker.rb
@@ -7,7 +7,7 @@ require 'lita-slack'
 # @note used during the Docker image generation
 Lita.configure do |config|
   config.robot.name = "Jarvis"
-  config.robot.locale = :en
+  config.robot.default_locale = :en
   config.robot.log_level = :info
 
   config.handlers.jarvis.cla_url = ""

--- a/lita_config.docker.rb
+++ b/lita_config.docker.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+# Configuration template, usable for production.
+# @note used during the Docker image generation
+Lita.configure do |config|
+  config.robot.name = "Jarvis"
+  config.robot.locale = :en
+  config.robot.log_level = :info
+
+  config.handlers.jarvis.cla_url = ""
+  config.handlers.jarvis.github_token = ENV['GITHUB_TOKEN']
+  config.http.host = "127.0.0.1"
+
+  config.robot.adapter = :slack
+  config.adapters.slack.token = ENV['SLACK_TOKEN']
+
+  # For pushing to rubygems.org ENV['GEM_HOST_API_KEY'] is also required
+end


### PR DESCRIPTION
This work is an dockerization effort for running Jarvis.

Jarvis uses Lita which depends on Redis being present on `localhost:6379`.
We're using the legacy `network_mode: host` to be able to run a single Docker image, 
alternatively a *docker-compose.yml* is present with another image exposing Redis to localhost.

Jarvis was running on MRI but assumes some of it's external process (plugin publishing) task to be run with JRuby.
The duality is maintained and both Rubies are installed in the generated image, the default Ruby being JRuby.

The resulting image depends on 3 (private) tokens provided from as environment variables for it's operations:
- `SLACK_TOKEN`
- `GITHUB_TOKEN`
- `GEM_HOST_API_KEY`

*p.s. Lita has been upgraded from 4.7.1 (that was running previously on AWS) to latest 4.8.0.*